### PR TITLE
Use Google Maps Javascript API 

### DIFF
--- a/css/islandora_simple_map.css
+++ b/css/islandora_simple_map.css
@@ -9,7 +9,7 @@
 }
 
 .block-islandora-simple-map .content,
-.islandora_simple_map_mapdiv {
+.islandora-simple-map-holder.islandora-simple-map-block {
   height: 100%;
   width: 100%;
   position: relative;

--- a/css/islandora_simple_map.css
+++ b/css/islandora_simple_map.css
@@ -1,0 +1,16 @@
+/*
+  Islandora Simple Map Base CSS
+ */
+
+.block-islandora-simple-map {
+  width: 200px;
+  height: 200px;
+  position: relative;
+}
+
+.block-islandora-simple-map .content,
+.islandora_simple_map_mapdiv {
+  height: 100%;
+  width: 100%;
+  position: relative;
+}

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -50,10 +50,8 @@ function islandora_simple_map_admin_settings() {
     ],
     'islandora_simple_maps_disable_page_display' => [
       '#type' => 'checkbox',
-      '#title' => t('Disable page map.'),
-      '#description' => t('Using Google Maps API allows you to add a' .
-        ' block to display the map, this toggle allows you to turn off the' .
-        ' normal page map.'),
+      '#title' => t('Disable collapsible div map.'),
+      '#description' => t('Using the Google Map API you can display the map in a block. This turns off the collapsible div map embed in the page.'),
       '#return_value' => TRUE,
       '#default_value' => variable_get('islandora_simple_maps_disable_page_display', FALSE),
       '#states' => [

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -48,6 +48,20 @@ function islandora_simple_map_admin_settings() {
         ],
       ],
     ],
+    'islandora_simple_maps_disable_page_display' => [
+      '#type' => 'checkbox',
+      '#title' => t('Disable page map.'),
+      '#description' => t('Using Google Maps API allows you to add a' .
+        ' block to display the map, this toggle allows you to turn off the' .
+        ' normal page map.'),
+      '#return_value' => TRUE,
+      '#default_value' => variable_get('islandora_simple_maps_disable_page_display', FALSE),
+      '#states' => [
+        'visible' => [
+          ':input[name="islandora_simple_map_use_gmaps_api"]' => ['checked' => TRUE],
+        ],
+      ],
+    ],
   ];
   $form['islandora_simple_map_xpath'] = array(
     '#title' => t('XPath expressions to MODS elements containing map data'),

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * @file
+ * Administrative forms.
+ */
+
+/**
+ * Admin settings form builder.
+ */
+function islandora_simple_map_admin_settings() {
+  $form = array();
+  $form['google_api'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Google Maps API'),
+    'islandora_simple_map_use_gmaps_api' => [
+      '#type' => 'checkbox',
+      '#title' => t('Use Google Maps API'),
+      '#description' => t('Use the Google Maps API, this requires registering for an API key.'),
+      '#return_value' => TRUE,
+      '#default_value' => variable_get('islandora_simple_map_use_gmaps_api', FALSE),
+    ],
+    'islandora_simple_map_google_maps_api_key' => [
+      '#type' => 'textfield',
+      '#title' => t('Google Maps API key'),
+      '#description' => format_string('A Google Maps API key, register for one <a href="@url">here</a>',
+        ['@url' => 'https://developers.google.com/maps/documentation/javascript/get-api-key']),
+      '#length' => 30,
+      '#maxlength' => 255,
+      '#default_value' => variable_get('islandora_simple_map_google_maps_api_key', ''),
+      '#states' => [
+        'required' => [
+          ':input[name="islandora_simple_map_use_gmaps_api"]' => ['checked' => TRUE],
+        ],
+        'visible' => [
+          ':input[name="islandora_simple_map_use_gmaps_api"]' => ['checked' => TRUE],
+        ],
+      ],
+    ],
+    'islandora_simple_maps_disable_scroll' => [
+      '#type' => 'checkbox',
+      '#title' => t('Disable mouse wheel scroll?'),
+      '#return_value' => TRUE,
+      '#default_value' => variable_get('islandora_simple_maps_disable_scroll', FALSE),
+      '#states' => [
+        'visible' => [
+          ':input[name="islandora_simple_map_use_gmaps_api"]' => ['checked' => TRUE],
+        ],
+      ],
+    ],
+  ];
+  $form['islandora_simple_map_xpath'] = array(
+    '#title' => t('XPath expressions to MODS elements containing map data'),
+    '#type' => 'textarea',
+    '#default_value' => variable_get('islandora_simple_map_xpath', ISLANDORA_SIMPLE_MAP_XPATHS),
+    '#description' => t("Enter one XPath expression per line, in preferred order with the most preferred first. The first data found in the object's MODS datastream by this list of XPath expressions will be used to populate the map."),
+  );
+  $form['islandora_simple_map_collapsed'] = array(
+    '#type' => 'select',
+    '#title' => t('Collapse map by default?'),
+    '#default_value' => variable_get('islandora_simple_map_collapsed', 'collapsed'),
+    '#options' => array(
+      'collapsed' => t('Collapsed'),
+      '' => t('Expanded'),
+    ),
+    '#description' => t('Whether or not the fieldset containing the map should be collapsed by default. The user can toggle the collapse.'),
+  );
+  $form['islandora_simple_map_iframe_width'] = array(
+    '#title' => t('Map iframe width'),
+    '#type' => 'textfield',
+    '#size' => 10,
+    '#default_value' => variable_get('islandora_simple_map_iframe_width', '600'),
+    '#description' => t('The width, in pixels, of the iframe the map will appear in.'),
+  );
+  $form['islandora_simple_map_iframe_height'] = array(
+    '#title' => t('Map iframe height'),
+    '#type' => 'textfield',
+    '#size' => 10,
+    '#default_value' => variable_get('islandora_simple_map_iframe_height', '600'),
+    '#description' => t('The height, in pixels, of the iframe the map will appear in.'),
+  );
+  $form['islandora_simple_map_zoom'] = array(
+    '#title' => t('Default zoom level'),
+    '#type' => 'textfield',
+    '#size' => 10,
+    '#default_value' => variable_get('islandora_simple_map_zoom', '10'),
+    '#description' => t('The higher the number, the higher the zoom.'),
+  );
+  $form['islandora_simple_map_attempt_cleanup'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Attempt to clean up map data.'),
+    '#default_value' => variable_get('islandora_simple_map_attempt_cleanup', 1),
+    '#description' => t('Check this option if you want to clean up data before passing it off to Google Maps. Please consult the README file for more information'),
+  );
+  $form['#validate'][] = 'islandora_simple_map_admin_settings_form_validate';
+  return system_settings_form($form);
+}
+
+/**
+ * Custom conditional required validation.
+ *
+ * @param array $form
+ *   Drupal form.
+ * @param array $form_state
+ *   Drupal form state.
+ */
+function islandora_simple_map_admin_settings_form_validate(array $form, array &$form_state) {
+  if ($form_state['values']['islandora_simple_map_use_gmaps_api'] == TRUE &&
+    empty($form_state['values']['islandora_simple_map_google_maps_api_key'])) {
+    form_set_error('islandora_simple_map_google_maps_api_key',
+      'You must include a Google Maps API key or not use the Google Maps API.');
+  }
+}

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -36,7 +36,7 @@ function islandora_simple_map_block_view($delta = '') {
           if (count($found_coords) > 0) {
             $map_div_id = drupal_html_id('islandora_simple_map_block');
             $settings = [];
-            $settings['islandora_simple_map'] = [
+            $settings['islandora_simple_map'][$map_div_id] = [
               'map_markers' => $found_coords,
               'map_div_id' => $map_div_id,
               'map_zoom_level' => (int) variable_get('islandora_simple_map_zoom', '10'),
@@ -48,7 +48,7 @@ function islandora_simple_map_block_view($delta = '') {
                   '#type' => 'container',
                   '#attributes' => [
                     'id' => $map_div_id,
-                    'class' => ['islandora_simple_map_mapdiv'],
+                    'class' => ['islandora-simple-map-holder', 'islandora-simple-map-block'],
                   ],
                 ],
                 '#attached' => [
@@ -66,7 +66,7 @@ function islandora_simple_map_block_view($delta = '') {
                       'data' => url("https://maps.googleapis.com/maps/api/js", [
                         'query' => [
                           'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
-                          'callback' => 'Drupal.islandora_simple_map.initMap',
+                          'callback' => 'Drupal.islandora_simple_map.initialize',
                         ],
                       ]),
                       'defer' => TRUE,
@@ -82,8 +82,8 @@ function islandora_simple_map_block_view($delta = '') {
               ],
             ];
           }
+          return $block;
         }
-        return $block;
       }
     }
   }

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @file
+ * Block related functions.
+ */
+
+/**
+ * Implements hook_block_info().
+ */
+function islandora_simple_map_block_info() {
+  $blocks = [];
+  if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+    $blocks['islandora_simple_map_object'] = [
+      'info' => t('Islandora Simple Map Object Block'),
+      'cache' => DRUPAL_NO_CACHE,
+    ];
+  }
+  return $blocks;
+}
+
+/**
+ * Implements hook_block_view().
+ */
+function islandora_simple_map_block_view($delta = '') {
+  if ($delta == 'islandora_simple_map_object') {
+    if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+      $object = menu_get_object('islandora_object', 2);
+      if ($object) {
+        if (isset($object['MODS'])) {
+          $module_path = drupal_get_path('module', 'islandora_simple_map');
+          $block = [];
+          module_load_include('inc', 'islandora_simple_map', 'includes/utilities');
+          $mods_string = $object['MODS']->content;
+          $found_coords = islandora_simple_map_parse_mods($mods_string);
+          if (count($found_coords) > 0) {
+            $map_div_id = drupal_html_id('islandora_simple_map_block');
+            $settings = [];
+            $settings['islandora_simple_map'] = [
+              'map_markers' => $found_coords,
+              'map_div_id' => $map_div_id,
+              'map_zoom_level' => (int) variable_get('islandora_simple_map_zoom', '10'),
+              'disable_scroll_zoom' => (bool) variable_get('islandora_simple_maps_disable_scroll', FALSE),
+            ];
+            $block = [
+              'content' => [
+                'islandora_simple_map_div' => [
+                  '#type' => 'container',
+                  '#attributes' => [
+                    'id' => $map_div_id,
+                    'class' => ['islandora_simple_map_mapdiv'],
+                  ],
+                ],
+                '#attached' => [
+                  'js' => [
+                    [
+                      'type' => 'setting',
+                      'data' => $settings,
+                    ],
+                    [
+                      'type' => 'file',
+                      'data' => "{$module_path}/js/object_map_markers.js",
+                    ],
+                    [
+                      'type' => 'external',
+                      'data' => url("https://maps.googleapis.com/maps/api/js", [
+                        'query' => [
+                          'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
+                          'callback' => 'Drupal.islandora_simple_map.initMap',
+                        ],
+                      ]),
+                      'defer' => TRUE,
+                    ],
+                  ],
+                  'css' => [
+                    [
+                      'type' => 'file',
+                      'data' => "{$module_path}/css/islandora_simple_map.css",
+                    ],
+                  ],
+                ],
+              ],
+            ];
+          }
+        }
+        return $block;
+      }
+    }
+  }
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -19,8 +19,7 @@ function islandora_simple_map_parse_mods($mods) {
   $found_coords = [];
 
   $mods_doc = new DOMDocument();
-  $mods_doc->loadXML($mods);
-  if ($mods_doc) {
+  if ($mods_doc->loadXML($mods)) {
     foreach ($xpaths as $xpath) {
       $xpath = trim($xpath);
       if (strlen($xpath)) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * General use functions.
+ */
+
+/**
+ * Parse a MODS record looking for coordinates.
+ *
+ * @param string $mods
+ *   The MODS document.
+ *
+ * @return array
+ *   Array of Lat/Lng coords.
+ */
+function islandora_simple_map_parse_mods($mods) {
+  $xpaths = preg_split('/$\R?^/m', trim(variable_get('islandora_simple_map_xpath', ISLANDORA_SIMPLE_MAP_XPATHS)));
+  $found_coords = [];
+
+  $mods_doc = new DOMDocument();
+  $mods_doc->loadXML($mods);
+  if ($mods_doc) {
+    foreach ($xpaths as $xpath) {
+      $xpath = trim($xpath);
+      if (strlen($xpath)) {
+        $mods_xpath = new DOMXPath($mods_doc);
+        $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
+        $mods_carto_xpath = $mods_xpath->query($xpath);
+        if ($mods_carto_xpath->length) {
+          // Take the first element found by the current XPath.
+          $mods_carto = $mods_carto_xpath->item(0);
+          $node_value = $mods_carto->nodeValue;
+          if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
+            $node_value = islandora_simple_map_clean_coordinates($node_value);
+          }
+          if (strlen($node_value)) {
+            $found_coords[] = $node_value;
+          }
+        }
+      }
+    }
+  }
+  return $found_coords;
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -26,8 +26,8 @@ function islandora_simple_map_parse_mods($mods) {
       if (strlen($xpath)) {
         $mods_xpath = new DOMXPath($mods_doc);
         $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
-        $mods_carto_xpath = $mods_xpath->query($xpath);
-        if ($mods_carto_xpath->length) {
+        $mods_carto_xpath = @$mods_xpath->query($xpath);
+        if ($mods_carto_xpath && $mods_carto_xpath->length > 0) {
           // Take the first element found by the current XPath.
           $mods_carto = $mods_carto_xpath->item(0);
           $node_value = $mods_carto->nodeValue;
@@ -42,4 +42,19 @@ function islandora_simple_map_parse_mods($mods) {
     }
   }
   return $found_coords;
+}
+
+
+/**
+ * Applies some cleanup on data to make it more reliable for Google Maps.
+ *
+ * @param string $data
+ *   The coordinate data.
+ *
+ * @return string
+ *   The cleaned up data.
+ */
+function islandora_simple_map_clean_coordinates($data) {
+  $data = preg_replace('/;/', ',', $data);
+  return $data;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -33,7 +33,7 @@ function islandora_simple_map_parse_mods($mods) {
           if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
             $node_value = islandora_simple_map_clean_coordinates($node_value);
           }
-          if (strlen($node_value)) {
+          if (strlen($node_value) && islandora_simple_map_is_valid_coordinates($node_value)) {
             $found_coords[] = $node_value;
           }
         }
@@ -42,7 +42,6 @@ function islandora_simple_map_parse_mods($mods) {
   }
   return $found_coords;
 }
-
 
 /**
  * Applies some cleanup on data to make it more reliable for Google Maps.
@@ -56,4 +55,19 @@ function islandora_simple_map_parse_mods($mods) {
 function islandora_simple_map_clean_coordinates($data) {
   $data = preg_replace('/;/', ',', $data);
   return $data;
+}
+
+/**
+ * Validate a coordinate, so we don't add text locations.
+ *
+ * @param string $coordinates
+ *   Whatever was returned by the configured XPath.
+ *
+ * @return bool
+ *   If it is a valid coordinate.
+ */
+function islandora_simple_map_is_valid_coordinates($coordinates) {
+  $coordinates = trim($coordinates);
+  $val = ((bool) preg_match('/^[+\-]?\d+(\.\d+)?\s*,\s*[+\-]?\d+(\.\d+)?$/', $coordinates));
+  return $val;
 }

--- a/islandora_simple_map.install
+++ b/islandora_simple_map.install
@@ -15,6 +15,9 @@ function islandora_simple_map_uninstall() {
     'islandora_simple_map_iframe_height',
     'islandora_simple_map_zoom',
     'islandora_simple_map_collapsed',
+    'islandora_simple_map_use_gmaps_api',
+    'islandora_simple_map_google_maps_api_key',
+    'islandora_simple_maps_disable_scroll',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_simple_map.install
+++ b/islandora_simple_map.install
@@ -18,6 +18,7 @@ function islandora_simple_map_uninstall() {
     'islandora_simple_map_use_gmaps_api',
     'islandora_simple_map_google_maps_api_key',
     'islandora_simple_maps_disable_scroll',
+    'islandora_simple_maps_disable_page_display',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -64,7 +64,7 @@ function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) 
       $module_path = drupal_get_path('module', 'islandora_simple_map');
       if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
         $map_div_id = drupal_html_id('islandora_simple_map_page');
-        $settings['islandora_simple_map'] = [
+        $settings['islandora_simple_map'][$map_div_id] = [
           'map_markers' => $found_coords,
           'map_div_id' => $map_div_id,
           'map_zoom_level' => $zoom,
@@ -81,7 +81,7 @@ function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) 
               '#type' => 'container',
               '#attributes' => [
                 'id' => $map_div_id,
-                'class' => ['islandora_simple_map_pagediv'],
+                'class' => ['islandora-simple-map-holder', 'islandora-simple-map-page'],
               ],
             ],
             '#attached' => [
@@ -101,7 +101,7 @@ function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) 
                   'data' => url("https://maps.googleapis.com/maps/api/js", [
                     'query' => [
                       'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
-                      'callback' => 'Drupal.islandora_simple_map.initMap',
+                      'callback' => 'Drupal.islandora_simple_map.initialize',
                     ],
                   ]),
                   'defer' => TRUE,

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -63,6 +63,9 @@ function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) 
       $collapsed = variable_get('islandora_simple_map_collapsed', 'collapsed');
       $module_path = drupal_get_path('module', 'islandora_simple_map');
       if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+        if (variable_get('islandora_simple_maps_disable_page_display', FALSE)) {
+          return [];
+        }
         $map_div_id = drupal_html_id('islandora_simple_map_page');
         $settings['islandora_simple_map'][$map_div_id] = [
           'map_markers' => $found_coords,

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -7,6 +7,9 @@
 
 define('ISLANDORA_SIMPLE_MAP_XPATHS', "//mods:subject/mods:cartographics/mods:coordinates\n//mods:subject/mods:geographic");
 
+// Includes blocks.
+require_once dirname(__FILE__) . '/includes/blocks.inc';
+
 /**
  * Implements hook_menu().
  */
@@ -19,59 +22,9 @@ function islandora_simple_map_menu() {
     'access arguments' => array('administer site configuration'),
     'page arguments' => array('islandora_simple_map_admin_settings'),
     'type' => MENU_NORMAL_ITEM,
+    'file' => 'includes/admin_form.inc',
   );
   return $items;
-}
-
-/**
- * Admin settings form builder.
- */
-function islandora_simple_map_admin_settings() {
-  $form = array();
-  $form['islandora_simple_map_xpath'] = array(
-    '#title' => t('XPath expressions to MODS elements containing map data'),
-    '#type' => 'textarea',
-    '#default_value' => variable_get('islandora_simple_map_xpath', ISLANDORA_SIMPLE_MAP_XPATHS),
-    '#description' => t("Enter one XPath expression per line, in preferred order with the most preferred first. The first data found in the object's MODS datastream by this list of XPath expressions will be used to populate the map."),
-  );
-  $form['islandora_simple_map_collapsed'] = array(
-    '#type' => 'select',
-    '#title' => t('Collapse map by default?'),
-    '#default_value' => variable_get('islandora_simple_map_collapsed', 'collapsed'),
-    '#options' => array(
-      'collapsed' => t('Collapsed'),
-      '' => t('Expanded'),
-    ),
-    '#description' => t('Whether or not the fieldset containing the map should be collapsed by default. The user can toggle the collapse.'),
-  );
-  $form['islandora_simple_map_iframe_width'] = array(
-    '#title' => t('Map iframe width'),
-    '#type' => 'textfield',
-    '#size' => 10,
-    '#default_value' => variable_get('islandora_simple_map_iframe_width', '600'),
-    '#description' => t('The width, in pixels, of the iframe the map will appear in.'),
-  );
-  $form['islandora_simple_map_iframe_height'] = array(
-    '#title' => t('Map iframe height'),
-    '#type' => 'textfield',
-    '#size' => 10,
-    '#default_value' => variable_get('islandora_simple_map_iframe_height', '600'),
-    '#description' => t('The height, in pixels, of the iframe the map will appear in.'),
-  );
-  $form['islandora_simple_map_zoom'] = array(
-    '#title' => t('Default zoom level'),
-    '#type' => 'textfield',
-    '#size' => 10,
-    '#default_value' => variable_get('islandora_simple_map_zoom', '10'),
-    '#description' => t('The higher the number, the higher the zoom.'),
-  );
-  $form['islandora_simple_map_attempt_cleanup'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Attempt to clean up map data.'),
-    '#default_value' => variable_get('islandora_simple_map_attempt_cleanup', 1),
-    '#description' => t('Check this option if you want to clean up data before passing it off to Google Maps. Please consult the README file for more information'),
-  );
-  return system_settings_form($form);
 }
 
 /**
@@ -97,48 +50,93 @@ function islandora_simple_map_theme() {
  * Implements hook_islandora_view_object_alter().
  */
 function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) {
-  $xpaths = preg_split('/$\R?^/m', trim(variable_get('islandora_simple_map_xpath', ISLANDORA_SIMPLE_MAP_XPATHS)));
-  $found_coords = array();
+  module_load_include('inc', 'islandora_simple_map', 'includes/utilities');
 
   if (isset($object['MODS'])) {
     $mods_string = $object['MODS']->content;
-    $mods_doc = new DOMDocument();
-    $mods_doc->loadXML($mods_string);
-    if ($mods_doc) {
-      foreach ($xpaths as $xpath) {
-        $xpath = trim($xpath);
-        if (strlen($xpath)) {
-          $mods_xpath = new DOMXPath($mods_doc);
-          $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
-          $mods_carto_xpath = $mods_xpath->query($xpath);
-          if ($mods_carto_xpath->length) {
-            // Take the first element found by the current XPath.
-            $mods_carto = $mods_carto_xpath->item(0);
-            $node_value = $mods_carto->nodeValue;
-            if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
-              $node_value = islandora_simple_map_clean_coordinates($node_value);
-            }
-            if (strlen($node_value)) {
-              $found_coords[] = $node_value;
-            }
-          }
-        }
-      }
-    }
+    $found_coords = islandora_simple_map_parse_mods($mods_string);
 
     if (count($found_coords)) {
-      $width = variable_get('islandora_simple_map_iframe_width', '600');
-      $height = variable_get('islandora_simple_map_iframe_height', '600');
-      $zoom = variable_get('islandora_simple_map_zoom', '10');
+      $width = (int) variable_get('islandora_simple_map_iframe_width', '600');
+      $height = (int) variable_get('islandora_simple_map_iframe_height', '600');
+      $zoom = (int) variable_get('islandora_simple_map_zoom', '10');
       $collapsed = variable_get('islandora_simple_map_collapsed', 'collapsed');
-      $markup = theme('islandora_simple_map', array(
-        // We use the first set of coords if our XPaths found more than one.
-        'coords' => urlencode($found_coords[0]),
-        'iframe_width' => $width,
-        'iframe_height' => $height,
-        'zoom' => $zoom,
-        'collapsed' => $collapsed,
-      ));
+      $module_path = drupal_get_path('module', 'islandora_simple_map');
+      if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+        $map_div_id = drupal_html_id('islandora_simple_map_page');
+        $settings['islandora_simple_map'] = [
+          'map_markers' => $found_coords,
+          'map_div_id' => $map_div_id,
+          'map_zoom_level' => $zoom,
+          'disable_scroll_zoom' => (bool) variable_get('islandora_simple_maps_disable_scroll', FALSE),
+        ];
+        $content = [
+          'islandora_simple_map' => [
+            '#type' => 'fieldset',
+            '#title' => t('Map'),
+            '#attributes' => [
+              'class' => ['collapsible', ($collapsed ? 'collapsed' : '')],
+            ],
+            'islandora_simple_map_div' => [
+              '#type' => 'container',
+              '#attributes' => [
+                'id' => $map_div_id,
+                'class' => ['islandora_simple_map_pagediv'],
+              ],
+            ],
+            '#attached' => [
+              'js' => [
+                'misc/collapse.js',
+                'misc/form.js',
+                [
+                  'type' => 'setting',
+                  'data' => $settings,
+                ],
+                [
+                  'type' => 'file',
+                  'data' => "{$module_path}/js/object_map_markers.js",
+                ],
+                [
+                  'type' => 'external',
+                  'data' => url("https://maps.googleapis.com/maps/api/js", [
+                    'query' => [
+                      'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
+                      'callback' => 'Drupal.islandora_simple_map.initMap',
+                    ],
+                  ]),
+                  'defer' => TRUE,
+                ],
+              ],
+              'css' => [
+                [
+                  'type' => 'file',
+                  'data' => "{$module_path}/css/islandora_simple_map.css",
+                ],
+                [
+                  'type' => 'inline',
+                  'data' => "#{$map_div_id} {\nheight: {$height}px;\nwidth: {$width}px;\n}",
+                ],
+              ],
+            ],
+          ],
+        ];
+        $markup = render($content);
+      }
+      else {
+
+        $width = variable_get('islandora_simple_map_iframe_width', '600');
+        $height = variable_get('islandora_simple_map_iframe_height', '600');
+        $zoom = variable_get('islandora_simple_map_zoom', '10');
+        $collapsed = variable_get('islandora_simple_map_collapsed', 'collapsed');
+        $markup = theme('islandora_simple_map', [
+          // We use the first set of coords if our XPaths found more than one.
+          'coords' => urlencode($found_coords[0]),
+          'iframe_width' => $width,
+          'iframe_height' => $height,
+          'zoom' => $zoom,
+          'collapsed' => $collapsed,
+        ]);
+      }
       // Some Islandora render arrays have a single member, with a key of NULL.
       if (isset($rendered[NULL])) {
         $rendered[NULL]['#markup'] = $rendered[NULL]['#markup'] . $markup;
@@ -150,6 +148,7 @@ function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) 
           $rendered[$member]['#markup'] = $rendered[$member]['#markup'] . $markup;
         }
       }
+
     }
   }
 }
@@ -158,7 +157,7 @@ function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) 
  * Applies some cleanup on data to make it more reliable for Google Maps.
  *
  * @param string $data
- *    The coordinate data.
+ *   The coordinate data.
  *
  * @return string
  *   The cleaned up data.
@@ -174,7 +173,7 @@ function islandora_simple_map_clean_coordinates($data) {
  * @param array $models
  *   The object's content models.
  *
- * @return string $member
+ * @return string
  *   The key identifiying the member in the render array.
  */
 function islandora_simple_map_get_rendered_member(array $models) {

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -157,20 +157,6 @@ function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) 
 }
 
 /**
- * Applies some cleanup on data to make it more reliable for Google Maps.
- *
- * @param string $data
- *   The coordinate data.
- *
- * @return string
- *   The cleaned up data.
- */
-function islandora_simple_map_clean_coordinates($data) {
-  $data = preg_replace('/;/', ',', $data);
-  return $data;
-}
-
-/**
  * Determines which member of the object's render array to append map to.
  *
  * @param array $models

--- a/js/object_map_markers.js
+++ b/js/object_map_markers.js
@@ -1,0 +1,44 @@
+(function (jQuery) {
+  Drupal.islandora_simple_map = {
+    maps: {},
+    initMap: function () {
+      if (typeof(Drupal.settings.islandora_simple_map) != 'undefined') {
+        var map_div = jQuery('#' + Drupal.settings.islandora_simple_map.map_div_id).get(0);
+        var coords = [];
+        for (var f = 0; f < Drupal.settings.islandora_simple_map.map_markers.length; f += 1) {
+          var item = Drupal.settings.islandora_simple_map.map_markers[f];
+          var c = item.split(',');
+          coords.push(new google.maps.LatLng(parseFloat(c[0].trim()),parseFloat(c[1].trim())));
+        }
+        var bounds = new google.maps.LatLngBounds();
+        var map = new google.maps.Map(map_div, {
+          zoom: parseInt(Drupal.settings.islandora_simple_map.map_zoom_level),
+          center: coords[0],
+          scrollwheel: (!Drupal.settings.islandora_simple_map.disable_scroll_zoom)
+        });
+        for (var f = 0; f < coords.length; f += 1){
+          bounds.extend(coords[f]);
+          new google.maps.Marker({
+            position: coords[f],
+            map: map
+          });
+        }
+        fieldsets = jQuery(map_div).closest('.collapsible.collapsed')
+        if (fieldsets.length > 0) {
+          for (var f = 0; f < fieldsets.length; f += 1) {
+            jQuery(fieldsets[f]).one('collapsed', function() {
+              window.setTimeout(function() {
+                Drupal.islandora_simple_map.redraw(map, bounds);
+              }, 200);
+            });
+          }
+        }
+        Drupal.islandora_simple_map.maps[Drupal.settings.islandora_simple_map.map_div_id] = map;
+      }
+    },
+    redraw: function(map, bounds) {
+      google.maps.event.trigger(map, 'resize');
+      map.panTo(bounds.getCenter());
+    }
+  }
+})(jQuery);

--- a/js/object_map_markers.js
+++ b/js/object_map_markers.js
@@ -1,39 +1,47 @@
 (function (jQuery) {
   Drupal.islandora_simple_map = {
     maps: {},
-    initMap: function () {
+    initialize: function() {
+      jQuery('.islandora-simple-map-holder').once('islandora-simple-map', function(){
+        Drupal.islandora_simple_map.initMap(this.id);
+      });
+    },
+    initMap: function(mapId) {
       if (typeof(Drupal.settings.islandora_simple_map) != 'undefined') {
-        var map_div = jQuery('#' + Drupal.settings.islandora_simple_map.map_div_id).get(0);
-        var coords = [];
-        for (var f = 0; f < Drupal.settings.islandora_simple_map.map_markers.length; f += 1) {
-          var item = Drupal.settings.islandora_simple_map.map_markers[f];
-          var c = item.split(',');
-          coords.push(new google.maps.LatLng(parseFloat(c[0].trim()),parseFloat(c[1].trim())));
-        }
-        var bounds = new google.maps.LatLngBounds();
-        var map = new google.maps.Map(map_div, {
-          zoom: parseInt(Drupal.settings.islandora_simple_map.map_zoom_level),
-          center: coords[0],
-          scrollwheel: (!Drupal.settings.islandora_simple_map.disable_scroll_zoom)
-        });
-        for (var f = 0; f < coords.length; f += 1){
-          bounds.extend(coords[f]);
-          new google.maps.Marker({
-            position: coords[f],
-            map: map
+        if (typeof(Drupal.settings.islandora_simple_map[mapId]) != 'undefined') {
+          var config = Drupal.settings.islandora_simple_map[mapId];
+          var map_div = jQuery('#' + mapId).get(0);
+          var coords = [];
+          for (var f = 0; f < config.map_markers.length; f += 1) {
+            var item = config.map_markers[f];
+            var c = item.split(',');
+            coords.push(new google.maps.LatLng(parseFloat(c[0].trim()), parseFloat(c[1].trim())));
+          }
+          var bounds = new google.maps.LatLngBounds();
+          var map = new google.maps.Map(map_div, {
+            zoom: parseInt(config.map_zoom_level),
+            center: coords[0],
+            scrollwheel: (!config.disable_scroll_zoom)
           });
-        }
-        fieldsets = jQuery(map_div).closest('.collapsible.collapsed')
-        if (fieldsets.length > 0) {
-          for (var f = 0; f < fieldsets.length; f += 1) {
-            jQuery(fieldsets[f]).one('collapsed', function() {
-              window.setTimeout(function() {
-                Drupal.islandora_simple_map.redraw(map, bounds);
-              }, 200);
+          for (var f = 0; f < coords.length; f += 1) {
+            bounds.extend(coords[f]);
+            new google.maps.Marker({
+              position: coords[f],
+              map: map
             });
           }
+          fieldsets = jQuery(map_div).closest('.collapsible.collapsed')
+          if (fieldsets.length > 0) {
+            for (var f = 0; f < fieldsets.length; f += 1) {
+              jQuery(fieldsets[f]).one('collapsed', function () {
+                window.setTimeout(function () {
+                  Drupal.islandora_simple_map.redraw(map, bounds);
+                }, 200);
+              });
+            }
+          }
+          Drupal.islandora_simple_map.maps[mapId] = map;
         }
-        Drupal.islandora_simple_map.maps[Drupal.settings.islandora_simple_map.map_div_id] = map;
       }
     },
     redraw: function(map, bounds) {


### PR DESCRIPTION
Javascript API: https://github.com/mjordan/islandora_simple_map/issues/7
Also:
* Allow disable of mouse scrolling: https://github.com/mjordan/islandora_simple_map/issues/11
* Add map block: https://github.com/mjordan/islandora_simple_map/issues/13

## DO NOT MERGE
This needs to be tested. I realized that I used square bracket array syntax, which is fine so long as you are using PHP 5.4 or greater. If necessary I can replace the `[]` with `array()`.

### What does this do
1. It moves the admin screen to a separate file.
2. It adds a block (the block should only appear if you are using the Google Maps API)
3. It copies :crossed_fingers: the old interface but using the GMaps API.
4. It adds an admin toggle to disable mouse wheel scrolling (left enabled by default).

For the normal display I used CSS to set the size of the map (still using the admin config options). But this way you could override it with CSS on individual pages.

### How to test
1. Install the PR
2. Go to Home » Administration » Islandora » Islandora Utility Modules » Islandora Simple Map.
3. Check off **Use Google Maps API**
4. Enter your **Google Maps API** key, there is a link to get one there.
5. **Save** the page.
6. Browse to an existing object with a map and see if it still works.
