### PR TITLE
Allow for multiple points

### DIFF
--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -61,6 +61,12 @@ function islandora_simple_map_admin_settings() {
       ],
     ],
   ];
+  $form['islandora_simple_map_coordinate_delimiter'] = [
+    '#type' => 'textfield',
+    '#title' => t('Coordinate delimiter'),
+    '#description' => t('Character or string used to separate multiple coordinates inside the MODS element, leave blank to not split.'),
+    '#default_value' => variable_get('islandora_simple_map_coordinate_delimiter', ';'),
+  ];
   $form['islandora_simple_map_xpath'] = array(
     '#title' => t('XPath expressions to MODS elements containing map data'),
     '#type' => 'textarea',
@@ -96,12 +102,13 @@ function islandora_simple_map_admin_settings() {
     '#type' => 'textfield',
     '#size' => 10,
     '#default_value' => variable_get('islandora_simple_map_zoom', '10'),
-    '#description' => t('The higher the number, the higher the zoom.'),
+    '#description' => t('The higher the number, the higher the zoom. If you have multiple points on a map, the zoom level may be lowered to fit all points on the map.'),
   );
   $form['islandora_simple_map_attempt_cleanup'] = array(
     '#type' => 'checkbox',
     '#title' => t('Attempt to clean up map data.'),
-    '#default_value' => variable_get('islandora_simple_map_attempt_cleanup', 1),
+    '#return_value' => TRUE,
+    '#default_value' => variable_get('islandora_simple_map_attempt_cleanup', TRUE),
     '#description' => t('Check this option if you want to clean up data before passing it off to Google Maps. Please consult the README file for more information'),
   );
   $form['#validate'][] = 'islandora_simple_map_admin_settings_form_validate';

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -20,28 +20,28 @@ function islandora_simple_map_parse_mods($mods) {
 
   $mods_doc = new DOMDocument();
   if ($mods_doc->loadXML($mods)) {
+    $mods_xpath = new DOMXPath($mods_doc);
+    $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
     foreach ($xpaths as $xpath) {
       $xpath = trim($xpath);
       if (strlen($xpath)) {
-        $mods_xpath = new DOMXPath($mods_doc);
-        $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
         $mods_carto_xpath = @$mods_xpath->query($xpath);
         if ($mods_carto_xpath && $mods_carto_xpath->length > 0) {
-          // Take the first element found by the current XPath.
-          $mods_carto = $mods_carto_xpath->item(0);
-          $node_value = $mods_carto->nodeValue;
-          if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
-            $node_value = islandora_simple_map_clean_coordinates($node_value);
-          }
-          if (strlen($node_value)) {
-            if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
-              if (islandora_simple_map_is_valid_coordinates($node_value)) {
-                // Filter non-coordinates if using the Javascript API.
-                $found_coords = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
-              }
+          foreach ($mods_carto_xpath as $mods_carto) {
+            $node_value = $mods_carto->nodeValue;
+            if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
+              $node_value = islandora_simple_map_clean_coordinates($node_value);
             }
-            else {
-              $found_coords[] = $node_value;
+            if (strlen($node_value) && islandora_simple_map_is_valid_coordinates($node_value)) {
+              if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
+                $temp_array = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
+                foreach ($temp_array as $item) {
+                  $found_coords[] = $item;
+                }
+              }
+              else {
+                $found_coords[] = $node_value;
+              }
             }
           }
         }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -30,14 +30,14 @@ function islandora_simple_map_parse_mods($mods) {
           // Take the first element found by the current XPath.
           $mods_carto = $mods_carto_xpath->item(0);
           $node_value = $mods_carto->nodeValue;
-          if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
+          if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
             $node_value = islandora_simple_map_clean_coordinates($node_value);
           }
           if (strlen($node_value)) {
             if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
               if (islandora_simple_map_is_valid_coordinates($node_value)) {
                 // Filter non-coordinates if using the Javascript API.
-                $found_coords[] = $node_value;
+                $found_coords = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
               }
             }
             else {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -35,13 +35,22 @@ function islandora_simple_map_parse_mods($mods) {
             if (strlen($node_value)) {
               if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
                 $temp_array = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
-                $temp_array = array_filter($temp_array, 'islandora_simple_map_is_valid_coordinates');
+                if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+                  $temp_array = array_filter($temp_array, 'islandora_simple_map_is_valid_coordinates');
+                }
                 foreach ($temp_array as $item) {
                   $found_coords[] = $item;
                 }
               }
-              elseif (islandora_simple_map_is_valid_coordinates($node_value)) {
-                $found_coords[] = $node_value;
+              else {
+                if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+                  if (islandora_simple_map_is_valid_coordinates($node_value)) {
+                    $found_coords[] = $node_value;
+                  }
+                }
+                else {
+                  $found_coords[] = $node_value;
+                }
               }
             }
           }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -32,14 +32,15 @@ function islandora_simple_map_parse_mods($mods) {
             if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
               $node_value = islandora_simple_map_clean_coordinates($node_value);
             }
-            if (strlen($node_value) && islandora_simple_map_is_valid_coordinates($node_value)) {
+            if (strlen($node_value)) {
               if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
                 $temp_array = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
+                $temp_array = array_filter($temp_array, 'islandora_simple_map_is_valid_coordinates');
                 foreach ($temp_array as $item) {
                   $found_coords[] = $item;
                 }
               }
-              else {
+              elseif (islandora_simple_map_is_valid_coordinates($node_value)) {
                 $found_coords[] = $node_value;
               }
             }

--- a/islandora_simple_map.install
+++ b/islandora_simple_map.install
@@ -19,6 +19,7 @@ function islandora_simple_map_uninstall() {
     'islandora_simple_map_google_maps_api_key',
     'islandora_simple_maps_disable_scroll',
     'islandora_simple_maps_disable_page_display',
+    'islandora_simple_map_coordinate_delimiter',
   );
   array_walk($variables, 'variable_del');
 }

--- a/js/object_map_markers.js
+++ b/js/object_map_markers.js
@@ -23,6 +23,8 @@
             center: coords[0],
             scrollwheel: (!config.disable_scroll_zoom)
           });
+          map.defaultZoom = map.getZoom();
+          map.initialZoom = true;
           for (var f = 0; f < coords.length; f += 1) {
             bounds.extend(coords[f]);
             new google.maps.Marker({
@@ -40,12 +42,25 @@
               });
             }
           }
+          else {
+            Drupal.islandora_simple_map.redraw(map, bounds);
+          }
+          // On first zoom called from map.fitBounds ensure we don't zoom closer.
+          google.maps.event.addListener(map, 'zoom_changed', function() {
+            if (map.initialZoom) {
+              if (map.getZoom() > map.defaultZoom) {
+                map.setZoom(map.defaultZoom);
+              }
+              map.initialZoom = false;
+            }
+          });
           Drupal.islandora_simple_map.maps[mapId] = map;
         }
       }
     },
     redraw: function(map, bounds) {
       google.maps.event.trigger(map, 'resize');
+      map.fitBounds(bounds);
       map.panTo(bounds.getCenter());
     }
   }


### PR DESCRIPTION
~~Relies on #14~~
Resolves #6 

## This will appear like a huge PR until #14 is merged.

Then it becomes a much more manageable PR.

## What does this do
This only works when using the Javascript API, otherwise you get the first coordinate found.

Adds a delimiter option which we split the MODS fields on. 

If you use the delimiter `;` you need to uncheck the `Attempt to clean up map data.` box for right now as it replaces semi-colons with commas.

It strips whitespace from the delimiter, so you can use a space as the delimiter.

Map adds each point to a [LntLngBounds](https://developers.google.com/maps/documentation/javascript/reference#LatLngBounds) and points at the center of it. It also checks the adjusted zoom level to ensure we zoom out to see all points but don't zoom in (relative to the configured default zoom) to fit.

This means if you have a small map (like a block for example) it will **lower** your initial zoom level to see all the points, but won't raise it.

![multi_simple_map](https://user-images.githubusercontent.com/2857697/28690326-61df7f6e-72de-11e7-93a9-9d160892ee0b.jpg)
