### PR TITLE
Allow using place names without Javascript API

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -33,8 +33,16 @@ function islandora_simple_map_parse_mods($mods) {
           if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
             $node_value = islandora_simple_map_clean_coordinates($node_value);
           }
-          if (strlen($node_value) && islandora_simple_map_is_valid_coordinates($node_value)) {
-            $found_coords[] = $node_value;
+          if (strlen($node_value)) {
+            if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+              if (islandora_simple_map_is_valid_coordinates($node_value)) {
+                // Filter non-coordinates if using the Javascript API.
+                $found_coords[] = $node_value;
+              }
+            }
+            else {
+              $found_coords[] = $node_value;
+            }
           }
         }
       }


### PR DESCRIPTION
@mjordan I broke the searching of Place names (described in [Readme here](https://github.com/mjordan/islandora_simple_map#using-place-names-and-other-non-coordinate-data-to-create-maps)). Using Place names doesn't seem to work with Javascript API, but I starting filtering out anything that was not a coordinate. 

This PR makes it so we only do filtering if you are using the Javascript API.