### PR TITLE
Use a hook to get coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,55 @@ Islandora module that appends a Google map to an object's display if its MODS da
 
 ## Overview
 
-This module can use geographic coordinates and place names in MODS elements to populate a Google map that is then appended to the object's display. Site admins can configure multiple MODS elements in a preferred order by entering XPath expressions in the admin setting's "XPath expressions to MODS elements containing map data" field. Data from the first element to match one of the configured XPath expressions is used to render the map. The module provide sensible default values that prefer `<subject><cartographics><coordinates>` over `<subject><geographic>`.
+This module can use geographic coordinates and place names in MODS elements to populate a Google map that is then appended to the object's display.
 
-### Using geographic coordinates to create maps
+This module allows use of Google Map's [Embed API](https://developers.google.com/maps/documentation/embed/) 
+or [Javascript API](https://developers.google.com/maps/documentation/javascript/) 
 
-By default, the MODS element this module expects geographic coordintates to be in is `<subject><cartographics><coordinates>`. Geographic coordinates must be in "decimal degrees" format with latitude listed first, then longitude. Google Maps is fairly forgiving of the specific formatting of the values. All of these work:
+If using the Javascript Map API option, a new map block is available.
+
+This module exposes a [hook](#api) to allow developers to write their own function to extract information and return coordinates for display on the map.
+
+See [Configuration](#configuration) for instructions.
+
+## Requirements
+
+* [Islandora](https://github.com/Islandora/islandora)
+
+Install as usual, see [this](https://drupal.org/documentation/install/modules-themes/modules-7) for further information.
+
+## Configuration
+
+If you choose to use the Javascript API you will need to [get an API Key](https://developers.google.com/maps/documentation/javascript/get-api-key).
+
+Admin settings are available at `admin/islandora/tools/islandora_simple_map`:
+
+Enabling the **Google Maps Javascript API** opens configuration for:
+
+* Your API key (required).
+* Disabling mouse wheel from causing map zoom.
+* Disable the map embed in the page. Useful if using the map block.
+
+It also displays **all** coordinates found, the Embed API only displays the first.
+
+Common configuration options are:
+
+* A delimiter to split multiple coordinates on.
+* the XPath expressions to the MODS elements where your map data is stored
+* the map's height, width, default zoom level, and whether or not the map is collapsed or expanded by default, and
+* option to clean up the data before it is passed to Google Maps.
+
+Once you enable the module, any object whose MODS file contains coordinates in the expected element will have a Google map appended to its display.
+
+### Extract from MODS using XPath
+
+Site admins can configure multiple MODS elements in a preferred order by entering XPath expressions in the admin setting's "XPath expressions to MODS elements containing map data" field. Data from the first element to match one of the configured XPath expressions is used to render the map. The module provide sensible default values that prefer `<subject><cartographics><coordinates>` over `<subject><geographic>`.
+
+#### Using geographic coordinates to create maps
+
+By default, the MODS element this module expects geographic coordintates to be in is `<subject><cartographics><coordinates>`. Geographic coordinates must be in "decimal degrees" format with latitude listed first, then longitude.
+
+Google Maps is fairly forgiving of the specific formatting of the values when _using the Embed API_. All of these work:
 
 ```
 +49.05444,-121.985
@@ -17,15 +61,40 @@ By default, the MODS element this module expects geographic coordintates to be i
 49.05444N121.985w
 ```
 
+When using the Javascript API the coordinates need to be in a comma separated decimal format. 
+```
++49.05444,-121.985
+```
+
+If your data is not in that format, you can create a small module using the [API](#api) to transform your data.
+
 Semicolons separating the latitude and longitude are not allowed, resulting in a map with no points on it:
 
 ```
 +49.05444;-121.985
 ```
 
-There is an admin option to "Attempt to clean up map data". If this is enabled (which it is by default), a semicolon in the data will be replaced with a comma before it is passed to Google Maps. Normally this option should be enabled, but if it interferes with your data in unexpected ways, it can be turned off.
+There is an admin option to "Attempt to clean up map data".
 
-### Using place names and other non-coordinate data to create maps
+If this is enabled (which **it is by default**), a semicolon in the data will be replaced with a comma before it is passed to Google Maps.
+
+This option can be enabled, but this cleaning occurs **before** splitting multiple coordinates. 
+So if semi-colons are used to delineate multiple coordinates this can cause problems.
+
+Example:
+
+`+49.05444,-121.985;+49.895077,-97.138451`
+becomes
+`+49.05444,-121.985,+49.895077,-97.138451`
+
+Then splitting on `;` would fail.
+
+Alternatively you can use multiple `<cartographic><coordinates></coordinates></cartographic>` elements and
+place one coordinate in each.
+
+#### Using place names and other non-coordinate data to create maps
+
+_Embed API Only_
 
 If you configure this module to use MODS elements that do not contain coordinate data, such as `<subject><geographic>`, Google Maps will attempt to generate a map based on whatever data it finds in the configured element. However, the results of using non-cartographic coordinates are not always predictable. For example, the following two values for `<subject><geographic>` produce accurate maps, presumably because they are unambiguous:
 
@@ -38,24 +107,17 @@ but a value of just `Dublin` results in a map showing the Irish city. Another ex
 
 The XPath expressions used to retrieve map data are executed in the order they are listed in the admin settings. So, for best results, listing the expressions in decreasing likelihood they will contain reliable and unambiguous data is the best strategy. The defaults values do this.
 
+**Note**: If you wish to reproduce this behaviour using the Javascript API you would need a new hook implementation using the 
+[Google Places API](https://developers.google.com/places/) to convert place names to coordinates.
 
-## Requirements
+## API
 
-* [Islandora](https://github.com/Islandora/islandora)
+`hook_islandora_simple_map_get_coordinates(AbstractObject $object)`
 
-Install as usual, see [this](https://drupal.org/documentation/install/modules-themes/modules-7) for further information.
-
-## Configuration
-
-Even though this module uses the Google Maps Embed API, no API key is required.
-
-Admin settings are available at `admin/islandora/tools/islandora_simple_map` for:
-
-* the XPath expressions to the MODS elements where your map data is stored
-* the map's height, width, default zoom level, and whether or not the map is collapsed or expanded by default, and
-* option to clean up the data before it is passed to Google Maps.
-
-Once you enable the module, any object whose MODS file contains coordinates in the expected element will have a Google map appended to its display.
+Implementations of this hook should return an array of decimal coordinates. 
+These are merged with all other implementations. 
+If you are using the Javascript API, they are then validated/filtered to ensure they are decimal coordinates.
+Lastly (using either API) they are de-duplicated to determine the points to show on the map.
 
 ## Maintainer
 
@@ -64,8 +126,6 @@ Once you enable the module, any object whose MODS file contains coordinates in t
 ## To do
 
 * Add support for non-Google maps.
-* Add support for the Google Maps Javascript API ([issue](https://github.com/mjordan/islandora_simple_map/issues/7))
-* Add support for using datastreams other than MODS for map data.
 * Add a Drupal permission to "View Islandora Simple Map maps".
 
 ## Development and feedback

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -12,11 +12,11 @@ function islandora_simple_map_admin_settings() {
   $form = array();
   $form['google_api'] = [
     '#type' => 'fieldset',
-    '#title' => t('Google Maps API'),
+    '#title' => t('Google Maps Javascript API'),
     'islandora_simple_map_use_gmaps_api' => [
       '#type' => 'checkbox',
-      '#title' => t('Use Google Maps API'),
-      '#description' => t('Use the Google Maps API, this requires registering for an API key.'),
+      '#title' => t('Use Google Maps Javascript API'),
+      '#description' => t('Use the Google Maps Javascript API, this requires registering for an API key.'),
       '#return_value' => TRUE,
       '#default_value' => variable_get('islandora_simple_map_use_gmaps_api', FALSE),
     ],

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -61,6 +61,12 @@ function islandora_simple_map_admin_settings() {
       ],
     ],
   ];
+  $form['islandora_simple_map_coordinate_delimiter'] = [
+    '#type' => 'textfield',
+    '#title' => t('Coordinate delimiter'),
+    '#description' => t('Character or string used to separate multiple coordinates inside the MODS element, leave blank to not split.'),
+    '#default_value' => variable_get('islandora_simple_map_coordinate_delimiter', ';'),
+  ];
   $form['islandora_simple_map_xpath'] = array(
     '#title' => t('XPath expressions to MODS elements containing map data'),
     '#type' => 'textarea',
@@ -96,12 +102,13 @@ function islandora_simple_map_admin_settings() {
     '#type' => 'textfield',
     '#size' => 10,
     '#default_value' => variable_get('islandora_simple_map_zoom', '10'),
-    '#description' => t('The higher the number, the higher the zoom.'),
+    '#description' => t('The higher the number, the higher the zoom. If you have multiple points on a map, the zoom level may be lowered to fit all points on the map.'),
   );
   $form['islandora_simple_map_attempt_cleanup'] = array(
     '#type' => 'checkbox',
     '#title' => t('Attempt to clean up map data.'),
-    '#default_value' => variable_get('islandora_simple_map_attempt_cleanup', 1),
+    '#return_value' => TRUE,
+    '#default_value' => variable_get('islandora_simple_map_attempt_cleanup', TRUE),
     '#description' => t('Check this option if you want to clean up data before passing it off to Google Maps. Please consult the README file for more information'),
   );
   $form['#validate'][] = 'islandora_simple_map_admin_settings_form_validate';

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -27,63 +27,60 @@ function islandora_simple_map_block_view($delta = '') {
     if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
       $object = menu_get_object('islandora_object', 2);
       if ($object) {
-        if (isset($object['MODS'])) {
+        module_load_include('inc', 'islandora_simple_map', 'includes/utilities');
+        $found_coords = islandora_simple_map_get_coordinates($object);
+        $block = [];
+        if (count($found_coords) > 0) {
           $module_path = drupal_get_path('module', 'islandora_simple_map');
-          $block = [];
-          module_load_include('inc', 'islandora_simple_map', 'includes/utilities');
-          $mods_string = $object['MODS']->content;
-          $found_coords = islandora_simple_map_parse_mods($mods_string);
-          if (count($found_coords) > 0) {
-            $map_div_id = drupal_html_id('islandora_simple_map_block');
-            $settings = [];
-            $settings['islandora_simple_map'][$map_div_id] = [
-              'map_markers' => $found_coords,
-              'map_div_id' => $map_div_id,
-              'map_zoom_level' => (int) variable_get('islandora_simple_map_zoom', '10'),
-              'disable_scroll_zoom' => (bool) variable_get('islandora_simple_maps_disable_scroll', FALSE),
-            ];
-            $block = [
-              'content' => [
-                'islandora_simple_map_div' => [
-                  '#type' => 'container',
-                  '#attributes' => [
-                    'id' => $map_div_id,
-                    'class' => ['islandora-simple-map-holder', 'islandora-simple-map-block'],
+          $map_div_id = drupal_html_id('islandora_simple_map_block');
+          $settings = [];
+          $settings['islandora_simple_map'][$map_div_id] = [
+            'map_markers' => $found_coords,
+            'map_div_id' => $map_div_id,
+            'map_zoom_level' => (int) variable_get('islandora_simple_map_zoom', '10'),
+            'disable_scroll_zoom' => (bool) variable_get('islandora_simple_maps_disable_scroll', FALSE),
+          ];
+          $block = [
+            'content' => [
+              'islandora_simple_map_div' => [
+                '#type' => 'container',
+                '#attributes' => [
+                  'id' => $map_div_id,
+                  'class' => ['islandora-simple-map-holder', 'islandora-simple-map-block'],
+                ],
+              ],
+              '#attached' => [
+                'js' => [
+                  [
+                    'type' => 'setting',
+                    'data' => $settings,
+                  ],
+                  [
+                    'type' => 'file',
+                    'data' => "{$module_path}/js/object_map_markers.js",
+                  ],
+                  [
+                    'type' => 'external',
+                    'data' => url("https://maps.googleapis.com/maps/api/js", [
+                      'query' => [
+                        'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
+                        'callback' => 'Drupal.islandora_simple_map.initialize',
+                      ],
+                    ]),
+                    'defer' => TRUE,
                   ],
                 ],
-                '#attached' => [
-                  'js' => [
-                    [
-                      'type' => 'setting',
-                      'data' => $settings,
-                    ],
-                    [
-                      'type' => 'file',
-                      'data' => "{$module_path}/js/object_map_markers.js",
-                    ],
-                    [
-                      'type' => 'external',
-                      'data' => url("https://maps.googleapis.com/maps/api/js", [
-                        'query' => [
-                          'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
-                          'callback' => 'Drupal.islandora_simple_map.initialize',
-                        ],
-                      ]),
-                      'defer' => TRUE,
-                    ],
-                  ],
-                  'css' => [
-                    [
-                      'type' => 'file',
-                      'data' => "{$module_path}/css/islandora_simple_map.css",
-                    ],
+                'css' => [
+                  [
+                    'type' => 'file',
+                    'data' => "{$module_path}/css/islandora_simple_map.css",
                   ],
                 ],
               ],
-            ];
-          }
-          return $block;
+            ],
+          ];
         }
+        return $block;
       }
     }
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -6,58 +6,58 @@
  */
 
 /**
- * Parse a MODS record looking for coordinates.
+ * Calls the hook_islandora_simple_map_get_coordinates() impls.
  *
- * @param string $mods
- *   The MODS document.
+ * @param AbstractObject $object
+ *   The object being viewed.
  *
  * @return array
- *   Array of Lat/Lng coords.
+ *   Array of unique decimal lat/lng points.
  */
-function islandora_simple_map_parse_mods($mods) {
-  $xpaths = preg_split('/$\R?^/m', trim(variable_get('islandora_simple_map_xpath', ISLANDORA_SIMPLE_MAP_XPATHS)));
-  $found_coords = [];
+function islandora_simple_map_get_coordinates(AbstractObject $object) {
+  $coordinates = (array) module_invoke_all(ISLANDORA_SIMPLE_MAP_COORDINATE_HOOK, $object);
+  if (count($coordinates) > 0) {
+    array_walk($coordinates, 'islandora_simple_map_standardize_format');
+    $coordinates = array_unique($coordinates);
+    $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
+    if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
+      array_walk($coordinates, 'islandora_simple_map_clean_coordinates');
+    }
+  }
+  return $coordinates;
+}
 
-  $mods_doc = new DOMDocument();
-  if ($mods_doc->loadXML($mods)) {
-    $mods_xpath = new DOMXPath($mods_doc);
-    $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
-    foreach ($xpaths as $xpath) {
-      $xpath = trim($xpath);
-      if (strlen($xpath)) {
-        $mods_carto_xpath = @$mods_xpath->query($xpath);
-        if ($mods_carto_xpath && $mods_carto_xpath->length > 0) {
-          foreach ($mods_carto_xpath as $mods_carto) {
-            $node_value = $mods_carto->nodeValue;
-            if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
-              $node_value = islandora_simple_map_clean_coordinates($node_value);
-            }
-            if (strlen($node_value)) {
-              if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
-                // Splitting on delimiter.
-                $coords = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
-                foreach ($coords as $coord) {
-                  if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
-                    // Using Javascript API, filter out non-decimal coordinates.
-                    if (islandora_simple_map_is_valid_coordinates($coord)) {
-                      $found_coords[] = $coord;
-                    }
-                  }
-                  else {
-                    // Splitting but not using Javascript API.
-                    $found_coords[] = $coord;
+/**
+ * Implements hook_islandora_simple_map_get_coordinates().
+ *
+ * Parse a MODS record looking for coordinates.
+ */
+function islandora_simple_map_islandora_simple_map_get_coordinates(AbstractObject $object) {
+  $found_coords = [];
+  if (isset($object['MODS'])) {
+    $mods = $object['MODS']->content;
+    $xpaths = preg_split('/$\R?^/m', trim(variable_get('islandora_simple_map_xpath', ISLANDORA_SIMPLE_MAP_XPATHS)));
+    $mods_doc = new DOMDocument();
+    if ($mods_doc->loadXML($mods)) {
+      $mods_xpath = new DOMXPath($mods_doc);
+      $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
+      foreach ($xpaths as $xpath) {
+        $xpath = trim($xpath);
+        if (strlen($xpath)) {
+          $mods_carto_xpath = @$mods_xpath->query($xpath);
+          if ($mods_carto_xpath && $mods_carto_xpath->length > 0) {
+            foreach ($mods_carto_xpath as $mods_carto) {
+              $node_value = $mods_carto->nodeValue;
+              if (strlen($node_value)) {
+                if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
+                  $temp_array = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
+                  foreach ($temp_array as $item) {
+                    $found_coords[] = $item;
                   }
                 }
-              }
-              elseif (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
-                // Not splitting but using Javascript API.
-                if (islandora_simple_map_is_valid_coordinates($node_value)) {
+                else {
                   $found_coords[] = $node_value;
                 }
-              }
-              else {
-                // Not splitting and not using Javascript API.
-                $found_coords[] = $node_value;
               }
             }
           }
@@ -95,4 +95,19 @@ function islandora_simple_map_is_valid_coordinates($coordinates) {
   $coordinates = trim($coordinates);
   $val = ((bool) preg_match('/^[+\-]?\d+(\.\d+)?\s*,\s*[+\-]?\d+(\.\d+)?$/', $coordinates));
   return $val;
+}
+
+/**
+ * Standardize coordinates to account for whitespace differences,.
+ *
+ * @param string $coordinates
+ *   A decimal coordinate.
+ *
+ * @return string
+ *   A cleaned up decimal coordinate.
+ */
+function islandora_simple_map_standardize_format($coordinates) {
+  if (preg_match('/^\s*([+\-]?\d+(\.\d+)?)\s*,\s*([+\-]?\d+(\.\d+))?\s*$/', $coordinates, $matches)) {
+    return format_string("!lat,!lng", ['!lat' => $matches[1], '!lng' => $matches[2]]);
+  }
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -17,15 +17,15 @@
 function islandora_simple_map_get_coordinates(AbstractObject $object) {
   $coordinates = (array) module_invoke_all(ISLANDORA_SIMPLE_MAP_COORDINATE_HOOK, $object);
   if (count($coordinates) > 0) {
+    if (variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
+      array_walk($coordinates, 'islandora_simple_map_clean_coordinates');
+    }
     if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
       // Only filter and standardize coordinates if we are using Javascript API.
       $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
       array_walk($coordinates, 'islandora_simple_map_standardize_format');
     }
     $coordinates = array_unique($coordinates);
-    if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
-      array_walk($coordinates, 'islandora_simple_map_clean_coordinates');
-    }
   }
   return $coordinates;
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -20,45 +20,45 @@ function islandora_simple_map_parse_mods($mods) {
 
   $mods_doc = new DOMDocument();
   if ($mods_doc->loadXML($mods)) {
+    $mods_xpath = new DOMXPath($mods_doc);
+    $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
     foreach ($xpaths as $xpath) {
       $xpath = trim($xpath);
       if (strlen($xpath)) {
-        $mods_xpath = new DOMXPath($mods_doc);
-        $mods_xpath->registerNamespace('mods', "http://www.loc.gov/mods/v3");
         $mods_carto_xpath = @$mods_xpath->query($xpath);
         if ($mods_carto_xpath && $mods_carto_xpath->length > 0) {
-          // Take the first element found by the current XPath.
-          $mods_carto = $mods_carto_xpath->item(0);
-          $node_value = $mods_carto->nodeValue;
-          if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
-            $node_value = islandora_simple_map_clean_coordinates($node_value);
-          }
-          if (strlen($node_value)) {
-            if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
-              // Splitting on delimiter.
-              $coords = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
-              foreach ($coords as $coord) {
-                if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
-                  // Using Javascript API, filter out non-decimal coordinates.
-                  if (islandora_simple_map_is_valid_coordinates($coord)) {
+          foreach ($mods_carto_xpath as $mods_carto) {
+            $node_value = $mods_carto->nodeValue;
+            if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
+              $node_value = islandora_simple_map_clean_coordinates($node_value);
+            }
+            if (strlen($node_value)) {
+              if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
+                // Splitting on delimiter.
+                $coords = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
+                foreach ($coords as $coord) {
+                  if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+                    // Using Javascript API, filter out non-decimal coordinates.
+                    if (islandora_simple_map_is_valid_coordinates($coord)) {
+                      $found_coords[] = $coord;
+                    }
+                  }
+                  else {
+                    // Splitting but not using Javascript API.
                     $found_coords[] = $coord;
                   }
                 }
-                else {
-                  // Splitting but not using Javascript API.
-                  $found_coords[] = $coord;
+              }
+              elseif (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+                // Not splitting but using Javascript API.
+                if (islandora_simple_map_is_valid_coordinates($node_value)) {
+                  $found_coords[] = $node_value;
                 }
               }
-            }
-            elseif (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
-              // Not splitting but using Javascript API.
-              if (islandora_simple_map_is_valid_coordinates($node_value)) {
+              else {
+                // Not splitting and not using Javascript API.
                 $found_coords[] = $node_value;
               }
-            }
-            else {
-              // Not splitting and not using Javascript API.
-              $found_coords[] = $node_value;
             }
           }
         }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -17,9 +17,9 @@
 function islandora_simple_map_get_coordinates(AbstractObject $object) {
   $coordinates = (array) module_invoke_all(ISLANDORA_SIMPLE_MAP_COORDINATE_HOOK, $object);
   if (count($coordinates) > 0) {
+    $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
     array_walk($coordinates, 'islandora_simple_map_standardize_format');
     $coordinates = array_unique($coordinates);
-    $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
     if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
       array_walk($coordinates, 'islandora_simple_map_clean_coordinates');
     }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -30,17 +30,34 @@ function islandora_simple_map_parse_mods($mods) {
           // Take the first element found by the current XPath.
           $mods_carto = $mods_carto_xpath->item(0);
           $node_value = $mods_carto->nodeValue;
-          if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
+          if ((bool) variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
             $node_value = islandora_simple_map_clean_coordinates($node_value);
           }
           if (strlen($node_value)) {
-            if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+            if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
+              // Splitting on delimiter.
+              $coords = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
+              foreach ($coords as $coord) {
+                if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+                  // Using Javascript API, filter out non-decimal coordinates.
+                  if (islandora_simple_map_is_valid_coordinates($coord)) {
+                    $found_coords[] = $coord;
+                  }
+                }
+                else {
+                  // Splitting but not using Javascript API.
+                  $found_coords[] = $coord;
+                }
+              }
+            }
+            elseif (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+              // Not splitting but using Javascript API.
               if (islandora_simple_map_is_valid_coordinates($node_value)) {
-                // Filter non-coordinates if using the Javascript API.
                 $found_coords[] = $node_value;
               }
             }
             else {
+              // Not splitting and not using Javascript API.
               $found_coords[] = $node_value;
             }
           }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -33,7 +33,32 @@ function islandora_simple_map_get_coordinates(AbstractObject $object) {
  * Parse a MODS record looking for coordinates.
  */
 function islandora_simple_map_islandora_simple_map_get_coordinates(AbstractObject $object) {
+  $mods_results = islandora_simple_map_get_mods_results($object);
   $found_coords = [];
+  foreach ($mods_results as $node_value) {
+    if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
+      $temp_array = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
+      foreach ($temp_array as $item) {
+        $found_coords[] = $item;
+      }
+    }
+    else {
+      $found_coords[] = $node_value;
+    }
+  }
+  return $found_coords;
+}
+
+/**
+ * Utility function to return the node values of the provided MODS.
+ *
+ * @param \AbstractObject $object
+ *   The Islandora object.
+ * @return array
+ *   The unaltered node values.
+ */
+function islandora_simple_map_get_mods_results(AbstractObject $object) {
+  $results = [];
   if (isset($object['MODS'])) {
     $mods = $object['MODS']->content;
     $xpaths = preg_split('/$\R?^/m', trim(variable_get('islandora_simple_map_xpath', ISLANDORA_SIMPLE_MAP_XPATHS)));
@@ -49,15 +74,7 @@ function islandora_simple_map_islandora_simple_map_get_coordinates(AbstractObjec
             foreach ($mods_carto_xpath as $mods_carto) {
               $node_value = $mods_carto->nodeValue;
               if (strlen($node_value)) {
-                if (strlen(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';'))) > 0) {
-                  $temp_array = explode(trim(variable_get('islandora_simple_map_coordinate_delimiter', ';')), $node_value);
-                  foreach ($temp_array as $item) {
-                    $found_coords[] = $item;
-                  }
-                }
-                else {
-                  $found_coords[] = $node_value;
-                }
+                $results[] = $node_value;
               }
             }
           }
@@ -65,7 +82,7 @@ function islandora_simple_map_islandora_simple_map_get_coordinates(AbstractObjec
       }
     }
   }
-  return $found_coords;
+  return $results;
 }
 
 /**

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -17,8 +17,11 @@
 function islandora_simple_map_get_coordinates(AbstractObject $object) {
   $coordinates = (array) module_invoke_all(ISLANDORA_SIMPLE_MAP_COORDINATE_HOOK, $object);
   if (count($coordinates) > 0) {
-    $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
-    array_walk($coordinates, 'islandora_simple_map_standardize_format');
+    if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+      // Only filter and standardize coordinates if we are using Javascript API.
+      $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
+      array_walk($coordinates, 'islandora_simple_map_standardize_format');
+    }
     $coordinates = array_unique($coordinates);
     if (variable_get('islandora_simple_map_attempt_cleanup', 1)) {
       array_walk($coordinates, 'islandora_simple_map_clean_coordinates');

--- a/islandora_simple_map.api.php
+++ b/islandora_simple_map.api.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Hook definition.
+ */
+
+/**
+ * Get alternate coordinate types and return them as decimal coordinates.
+ *
+ * @param AbstractObject $object
+ *   The Islandora object.
+ *
+ * @return array
+ *   Array of coordinates in decimal format.
+ */
+function hook_islandora_simple_map_get_coordinates(AbstractObject $object) {
+  if (isset($object['coordinates'])) {
+    $datastream_content = trim($object['coordinates']->content);
+    $coordinates = array();
+    $temporary_array = explode(';', $datastream_content);
+    foreach ($temporary_array as $coord) {
+      $coordinates[] = $coord;
+    }
+    return $coordinates;
+  }
+}

--- a/islandora_simple_map.install
+++ b/islandora_simple_map.install
@@ -19,6 +19,7 @@ function islandora_simple_map_uninstall() {
     'islandora_simple_map_google_maps_api_key',
     'islandora_simple_maps_disable_scroll',
     'islandora_simple_maps_disable_page_display',
+    'islandora_simple_map_coordinate_delimiter',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -6,6 +6,7 @@
  */
 
 define('ISLANDORA_SIMPLE_MAP_XPATHS', "//mods:subject/mods:cartographics/mods:coordinates\n//mods:subject/mods:geographic");
+define('ISLANDORA_SIMPLE_MAP_COORDINATE_HOOK', 'islandora_simple_map_get_coordinates');
 
 // Includes blocks.
 require_once dirname(__FILE__) . '/includes/blocks.inc';
@@ -52,107 +53,103 @@ function islandora_simple_map_theme() {
 function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) {
   module_load_include('inc', 'islandora_simple_map', 'includes/utilities');
 
-  if (isset($object['MODS'])) {
-    $mods_string = $object['MODS']->content;
-    $found_coords = islandora_simple_map_parse_mods($mods_string);
-
-    if (count($found_coords)) {
-      $width = (int) variable_get('islandora_simple_map_iframe_width', '600');
-      $height = (int) variable_get('islandora_simple_map_iframe_height', '600');
-      $zoom = (int) variable_get('islandora_simple_map_zoom', '10');
-      $collapsed = variable_get('islandora_simple_map_collapsed', 'collapsed');
-      $module_path = drupal_get_path('module', 'islandora_simple_map');
-      if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
-        if (variable_get('islandora_simple_maps_disable_page_display', FALSE)) {
-          return [];
-        }
-        $map_div_id = drupal_html_id('islandora_simple_map_page');
-        $settings['islandora_simple_map'][$map_div_id] = [
-          'map_markers' => $found_coords,
-          'map_div_id' => $map_div_id,
-          'map_zoom_level' => $zoom,
-          'disable_scroll_zoom' => (bool) variable_get('islandora_simple_maps_disable_scroll', FALSE),
-        ];
-        $content = [
-          'islandora_simple_map' => [
-            '#type' => 'fieldset',
-            '#title' => t('Map'),
+  $found_coords = islandora_simple_map_get_coordinates($object);
+  if (count($found_coords)) {
+    $width = (int) variable_get('islandora_simple_map_iframe_width', '600');
+    $height = (int) variable_get('islandora_simple_map_iframe_height', '600');
+    $zoom = (int) variable_get('islandora_simple_map_zoom', '10');
+    $collapsed = variable_get('islandora_simple_map_collapsed', 'collapsed');
+    $module_path = drupal_get_path('module', 'islandora_simple_map');
+    if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+      if (variable_get('islandora_simple_maps_disable_page_display', FALSE)) {
+        return [];
+      }
+      $map_div_id = drupal_html_id('islandora_simple_map_page');
+      $settings['islandora_simple_map'][$map_div_id] = [
+        'map_markers' => $found_coords,
+        'map_div_id' => $map_div_id,
+        'map_zoom_level' => $zoom,
+        'disable_scroll_zoom' => (bool) variable_get('islandora_simple_maps_disable_scroll', FALSE),
+      ];
+      $content = [
+        'islandora_simple_map' => [
+          '#type' => 'fieldset',
+          '#title' => t('Map'),
+          '#attributes' => [
+            'class' => ['collapsible', ($collapsed ? 'collapsed' : '')],
+          ],
+          'islandora_simple_map_div' => [
+            '#type' => 'container',
             '#attributes' => [
-              'class' => ['collapsible', ($collapsed ? 'collapsed' : '')],
+              'id' => $map_div_id,
+              'class' => ['islandora-simple-map-holder', 'islandora-simple-map-page'],
             ],
-            'islandora_simple_map_div' => [
-              '#type' => 'container',
-              '#attributes' => [
-                'id' => $map_div_id,
-                'class' => ['islandora-simple-map-holder', 'islandora-simple-map-page'],
+          ],
+          '#attached' => [
+            'js' => [
+              'misc/collapse.js',
+              'misc/form.js',
+              [
+                'type' => 'setting',
+                'data' => $settings,
+              ],
+              [
+                'type' => 'file',
+                'data' => "{$module_path}/js/object_map_markers.js",
+              ],
+              [
+                'type' => 'external',
+                'data' => url("https://maps.googleapis.com/maps/api/js", [
+                  'query' => [
+                    'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
+                    'callback' => 'Drupal.islandora_simple_map.initialize',
+                  ],
+                ]),
+                'defer' => TRUE,
               ],
             ],
-            '#attached' => [
-              'js' => [
-                'misc/collapse.js',
-                'misc/form.js',
-                [
-                  'type' => 'setting',
-                  'data' => $settings,
-                ],
-                [
-                  'type' => 'file',
-                  'data' => "{$module_path}/js/object_map_markers.js",
-                ],
-                [
-                  'type' => 'external',
-                  'data' => url("https://maps.googleapis.com/maps/api/js", [
-                    'query' => [
-                      'key' => variable_get('islandora_simple_map_google_maps_api_key', ''),
-                      'callback' => 'Drupal.islandora_simple_map.initialize',
-                    ],
-                  ]),
-                  'defer' => TRUE,
-                ],
+            'css' => [
+              [
+                'type' => 'file',
+                'data' => "{$module_path}/css/islandora_simple_map.css",
               ],
-              'css' => [
-                [
-                  'type' => 'file',
-                  'data' => "{$module_path}/css/islandora_simple_map.css",
-                ],
-                [
-                  'type' => 'inline',
-                  'data' => "#{$map_div_id} {\nheight: {$height}px;\nwidth: {$width}px;\n}",
-                ],
+              [
+                'type' => 'inline',
+                'data' => "#{$map_div_id} {\nheight: {$height}px;\nwidth: {$width}px;\n}",
               ],
             ],
           ],
-        ];
-        $markup = render($content);
-      }
-      else {
-
-        $width = variable_get('islandora_simple_map_iframe_width', '600');
-        $height = variable_get('islandora_simple_map_iframe_height', '600');
-        $zoom = variable_get('islandora_simple_map_zoom', '10');
-        $collapsed = variable_get('islandora_simple_map_collapsed', 'collapsed');
-        $markup = theme('islandora_simple_map', [
-          // We use the first set of coords if our XPaths found more than one.
-          'coords' => urlencode($found_coords[0]),
-          'iframe_width' => $width,
-          'iframe_height' => $height,
-          'zoom' => $zoom,
-          'collapsed' => $collapsed,
-        ]);
-      }
-      // Some Islandora render arrays have a single member, with a key of NULL.
-      if (isset($rendered[NULL])) {
-        $rendered[NULL]['#markup'] = $rendered[NULL]['#markup'] . $markup;
-      }
-      else {
-        // Others have several members, depending on the content model.
-        $member = islandora_simple_map_get_rendered_member($object->models);
-        if (isset($rendered[$member]['#markup'])) {
-          $rendered[$member]['#markup'] = $rendered[$member]['#markup'] . $markup;
-        }
-      }
-
+        ],
+      ];
+      $markup = render($content);
     }
+    else {
+
+      $width = variable_get('islandora_simple_map_iframe_width', '600');
+      $height = variable_get('islandora_simple_map_iframe_height', '600');
+      $zoom = variable_get('islandora_simple_map_zoom', '10');
+      $collapsed = variable_get('islandora_simple_map_collapsed', 'collapsed');
+      $markup = theme('islandora_simple_map', [
+        // We use the first set of coords if our XPaths found more than one.
+        'coords' => urlencode($found_coords[0]),
+        'iframe_width' => $width,
+        'iframe_height' => $height,
+        'zoom' => $zoom,
+        'collapsed' => $collapsed,
+      ]);
+    }
+    // Some Islandora render arrays have a single member, with a key of NULL.
+    if (isset($rendered[NULL])) {
+      $rendered[NULL]['#markup'] = $rendered[NULL]['#markup'] . $markup;
+    }
+    else {
+      // Others have several members, depending on the content model.
+      $member = islandora_simple_map_get_rendered_member($object->models);
+      if (isset($rendered[$member]['#markup'])) {
+        $rendered[$member]['#markup'] = $rendered[$member]['#markup'] . $markup;
+      }
+    }
+
   }
 }
 

--- a/js/object_map_markers.js
+++ b/js/object_map_markers.js
@@ -23,6 +23,8 @@
             center: coords[0],
             scrollwheel: (!config.disable_scroll_zoom)
           });
+          map.defaultZoom = map.getZoom();
+          map.initialZoom = true;
           for (var f = 0; f < coords.length; f += 1) {
             bounds.extend(coords[f]);
             new google.maps.Marker({
@@ -40,12 +42,25 @@
               });
             }
           }
+          else {
+            Drupal.islandora_simple_map.redraw(map, bounds);
+          }
+          // On first zoom called from map.fitBounds ensure we don't zoom closer.
+          google.maps.event.addListener(map, 'zoom_changed', function() {
+            if (map.initialZoom) {
+              if (map.getZoom() > map.defaultZoom) {
+                map.setZoom(map.defaultZoom);
+              }
+              map.initialZoom = false;
+            }
+          });
           Drupal.islandora_simple_map.maps[mapId] = map;
         }
       }
     },
     redraw: function(map, bounds) {
       google.maps.event.trigger(map, 'resize');
+      map.fitBounds(bounds);
       map.panTo(bounds.getCenter());
     }
   }


### PR DESCRIPTION
Relies on #15 - Multiple points
Resolves #18 

This adds a hook `hook_islandora_simple_map_get_coordinates(AbstractObject $object)`.

The hook is passed the current object and should return an array of any points to be added to the maps.

I created a small [example module](https://github.com/whikloj/example_degrees_coords) that uses this hook for decoding DSM coordinates into decimals.
