### PR TITLE
Issue 38

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Common configuration options are:
 * the map's height, width, default zoom level, and whether or not the map is collapsed or expanded by default, and
 * option to clean up the data before it is passed to Google Maps.
 * option to enable maps on collections.
+* option to display maps for compounds (in addition to their first child).
 
 Once you enable the module, any object whose MODS file contains coordinates in the expected element will have a Google map appended to its display.
 

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -142,6 +142,13 @@ function islandora_simple_map_admin_settings() {
     '#default_value' => variable_get('islandora_simple_map_attempt_cleanup', TRUE),
     '#description' => t('Check this option if you want to clean up data before passing it off to Google Maps. Please consult the README file for more information'),
   );
+  $form['islandora_simple_map_omit_compound_display'] = array(
+    '#type' => 'checkbox',
+    '#title' => t("Don't display maps for compound parents."),
+    '#description' => t("Compounds render as themselves and their first child, so you get two maps. This removes the compound's map."),
+    '#return_value' => TRUE,
+    '#default_value' => variable_get('islandora_simple_map_omit_compound_display', TRUE),
+  );
   $form['#validate'][] = 'islandora_simple_map_admin_settings_form_validate';
   return system_settings_form($form);
 }

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -117,6 +117,10 @@ function islandora_simple_map_collection_tab_access(AbstractObject $object) {
  * Implements hook_islandora_view_object_alter().
  */
 function islandora_simple_map_islandora_view_object_alter(&$object, &$rendered) {
+  if (in_array('islandora:compoundCModel', $object->models) &&
+    variable_get('islandora_simple_map_omit_compound_display', TRUE)) {
+    return array();
+  }
   $found_coords = islandora_simple_map_process_coordinates($object);
   if (isset($found_coords['coordinates']) && count($found_coords['coordinates']) > 0) {
     $width = (int) variable_get('islandora_simple_map_iframe_width', '600');


### PR DESCRIPTION
Resolves #38 

If you have a compound object that has coordinates, then when you view it. You get a map for the compound but because it also renders the first child object you will get a second map using the coordinates from the first child.

By default a compound will **not** display its own map and depends on the first child, but you can un-check the new admin option to disable this.