### PR TITLE
Query Solr for the coordinates of members of a collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Once you enable the module, any object whose MODS file contains coordinates in t
 
 If you have checked the "Enable collection level maps?" option, you can then enable a map for each collection within the collection's Manage subtabs.
 
+There is also the __Coordinates Solr field__ option if you index your object's coordinates. If you fill this in, then a
+Solr query will be done to retrieve the collections coordinates instead of parsing each collection member's MODS record.
+
 ### Extract from MODS using XPath
 
 Site admins can configure multiple MODS elements in a preferred order by entering XPath expressions in the admin setting's "XPath expressions to MODS elements containing map data" field. Data from the first element to match one of the configured XPath expressions is used to render the map. The module provide sensible default values that prefer `<subject><cartographics><coordinates>` over `<subject><geographic>`.

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -60,32 +60,36 @@ function islandora_simple_map_admin_settings() {
         ),
       ),
     ),
-    'islandora_simple_map_collections' => array(
-      '#type' => 'fieldset',
-      '#title' => t('Collection Maps'),
+    'islandora_simple_map_collection_maps' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable collection level maps?'),
+      '#description' => t('Aggregate object markers inside a collection into a single map for the collection.'),
+      '#default_value' => variable_get('islandora_simple_map_collection_maps', FALSE),
+      '#return_value' => TRUE,
+    ),
+  );
+  $form['islandora_simple_map_solr_fieldset'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Solr settings'),
+    'islandora_simple_map_use_solr' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Use Solr for object map queries.'),
+      '#description' => t('Use Solr to query the coordinates of an object and/or collection.'),
+      '#default_value' => variable_get('islandora_simple_map_use_solr', FALSE),
+    ),
+    'islandora_simple_map_solr_wrapper' => array(
+      '#type' => 'container',
       '#states' => array(
         'visible' => array(
-          ':input[name="islandora_simple_map_use_gmaps_api"]' => array('checked' => TRUE),
+          ':input[name="islandora_simple_map_use_solr"]' => array('checked' => TRUE),
         ),
       ),
-      'islandora_simple_map_collection_maps' => array(
-        '#type' => 'checkbox',
-        '#title' => t('Enable collection level maps?'),
-        '#description' => t('Aggregate object markers inside a collection into a single map for the collection.'),
-        '#default_value' => variable_get('islandora_simple_map_collection_maps', FALSE),
-        '#return_value' => TRUE,
-      ),
-      'islandora_simple_map_collection_coord_solr_field' => array(
+      'islandora_simple_map_coordinate_solr_field' => array(
         '#type' => 'textfield',
         '#title' => t('Coordinates Solr field.'),
-        '#description' => t('Solr field with the coordinates from a records, can be multivalued.'),
-        '#default_value' => variable_get('islandora_simple_map_collection_coord_solr_field', ''),
+        '#description' => t('Solr field with the coordinates from a record, can be multivalued.'),
+        '#default_value' => variable_get('islandora_simple_map_coordinate_solr_field', ''),
         '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
-        '#states' => array(
-          'visible' => array(
-            ':input[name="islandora_simple_map_collection_maps"]' => array('checked' => TRUE),
-          ),
-        ),
       ),
     ),
   );
@@ -156,6 +160,11 @@ function islandora_simple_map_admin_settings_form_validate(array $form, array &$
     empty($form_state['values']['islandora_simple_map_google_maps_api_key'])) {
     form_set_error('islandora_simple_map_google_maps_api_key',
       'You must include a Google Maps API key or not use the Google Maps API.');
+  }
+  if (empty($form_state['values']['islandora_simple_map_coordinate_solr_field'])
+    && $form_state['values']['islandora_simple_map_use_solr'] == TRUE) {
+    form_set_error('islandora_simple_map_coordinate_solr_field',
+      'You must specify a field for coordinates to use Solr.');
   }
 }
 

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -82,9 +82,6 @@ function islandora_simple_map_admin_settings() {
         '#default_value' => variable_get('islandora_simple_map_collection_coord_solr_field', ''),
         '#autocomplete_path' => 'islandora_solr/autocomplete_luke',
         '#states' => array(
-          'required' => array(
-            ':input[name="islandora_simple_map_collection_maps"]' => array('checked' => TRUE),
-          ),
           'visible' => array(
             ':input[name="islandora_simple_map_collection_maps"]' => array('checked' => TRUE),
           ),
@@ -159,12 +156,6 @@ function islandora_simple_map_admin_settings_form_validate(array $form, array &$
     empty($form_state['values']['islandora_simple_map_google_maps_api_key'])) {
     form_set_error('islandora_simple_map_google_maps_api_key',
       'You must include a Google Maps API key or not use the Google Maps API.');
-  }
-  if ($form_state['values']['islandora_simple_map_use_gmaps_api'] == TRUE &&
-    $form_state['values']['islandora_simple_map_collection_maps'] == TRUE &&
-    empty($form_state['values']['islandora_simple_map_collection_coord_solr_field'])) {
-    form_set_error('islandora_simple_map_collection_coord_solr_field',
-      'You must set a coordinate Solr field to enable Collections maps.');
   }
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -322,12 +322,12 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
         $coords = $member['solr_doc'][$coord_field];
       }
       else {
-        $coords = [$member['solr_doc'][$coord_field]];
+        $coords = array($member['solr_doc'][$coord_field]);
       }
-      $points[] = [
+      $points[] = array(
         'pid' => $member['PID'],
         'coordinates' => $coords,
-      ];
+      );
     }
   }
   $points = array_filter($points, function($o) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -290,7 +290,7 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
   $page_num = 0;
   $page_size = 20;
   $count = NULL;
-  $members = [];
+  $members = array();
   $solr_build = new IslandoraSolrQueryProcessor();
   $params = [
     'rows' => $page_size,

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -292,16 +292,16 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
   $count = NULL;
   $members = array();
   $solr_build = new IslandoraSolrQueryProcessor();
-  $params = [
+  $params = array(
     'rows' => $page_size,
     'start' => $page_num,
     'fl' => "PID,{$coord_field}",
-  ];
+  );
   $solr_query = format_string("!member:\"!pid\" OR !member:\"info:fedora/!pid\"",
-    [
+    array(
       '!member' => $member_field,
       '!pid' => $object->id,
-    ]
+    )
   );
   while (is_null($count) || ($count > ($page_num * $page_size) + $page_size)) {
     try {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -392,7 +392,7 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
         array_walk($coordinates, 'islandora_simple_map_clean_coordinates');
       }
       if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
-        // Only filter and standardize coordinates if we are using Javascript API.
+        // Only filter/standardize coordinates if we are using Javascript API.
         $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
         array_walk($coordinates, 'islandora_simple_map_standardize_format');
       }
@@ -453,7 +453,7 @@ function _islandora_simple_map_generate_js_code(array $settings) {
 }
 
 /**
- * Remove the various search alters that stop us from getting any data from Solr.
+ * Remove search alters that stop us from getting any data from Solr.
  *
  * @param array $params
  *   The islandoraSolrQueryProcessor params

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -98,7 +98,7 @@ function islandora_simple_map_parse_coordinates(array $coordinates) {
  */
 function islandora_simple_map_islandora_simple_map_get_coordinates(AbstractObject $object) {
   $found_coords = array();
-  if (variable_get('islandora_simple_map_use_solr', FALSE)) {
+  if (module_exists("islandora_solr") && variable_get('islandora_simple_map_use_solr', FALSE)) {
     $found_coords = _islandora_simple_map_get_coordinates_solr($object);
   }
   else {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -233,7 +233,7 @@ function _islandora_simple_map_get_collection_points(AbstractObject $object) {
   if (module_exists('islandora_solr') && variable_get('islandora_simple_map_collection_coord_solr_field', '') !== '') {
     $points = _islandora_simple_map_get_collection_points_solr($object);
   }
-  else if (module_exists('islandora_basic_collection')) {
+  elseif (module_exists('islandora_basic_collection')) {
     $points = _islandora_simple_map_get_collection_points_load($object);
   }
   return $points;
@@ -310,8 +310,9 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
       $count = $results['response']['numFound'];
       $members = array_merge($members, $results['response']['objects']);
       $page_num += 1;
-    } catch (Exception $e) {
-      drupal_set_message("Error querying Solr index: {$e->getMessage}", "error");
+    }
+    catch (Exception $e) {
+      drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error');
       break;
     }
   }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -95,10 +95,28 @@ function islandora_simple_map_parse_coordinates(array $coordinates) {
 
 /**
  * Implements hook_islandora_simple_map_get_coordinates().
- *
- * Parse a MODS record looking for coordinates.
  */
 function islandora_simple_map_islandora_simple_map_get_coordinates(AbstractObject $object) {
+  $found_coords = array();
+  if (variable_get('islandora_simple_map_use_solr', FALSE)) {
+    $found_coords = _islandora_simple_map_get_coordinates_solr($object);
+  }
+  else {
+    $found_coords = _islandora_simple_map_get_coordinates_parse_mods($object);
+  }
+  return $found_coords;
+}
+
+/**
+ * Parse a MODS record looking for coordinates.
+ *
+ * @param AbstractObject $object
+ *   Object to find coordinates for.
+ *
+ * @return array
+ *   Array of raw coordinates.
+ */
+function _islandora_simple_map_get_coordinates_parse_mods(AbstractObject $object) {
   $mods_results = islandora_simple_map_get_mods_results($object);
   $found_coords = array();
   foreach ($mods_results as $node_value) {
@@ -110,6 +128,48 @@ function islandora_simple_map_islandora_simple_map_get_coordinates(AbstractObjec
     }
     else {
       $found_coords[] = $node_value;
+    }
+  }
+  return $found_coords;
+}
+
+/**
+ * Search Solr for coordinates.
+ *
+ * @param AbstractObject $object
+ *   Object to find coordinates for.
+ *
+ * @return array
+ *   Array of raw coordinates.
+ */
+function _islandora_simple_map_get_coordinates_solr(AbstractObject $object) {
+  $coord_field = variable_get('islandora_simple_map_coordinate_solr_field', '');
+  $found_coords = array();
+  $solr_build = new IslandoraSolrQueryProcessor();
+  $params = array(
+    'fl' => "PID,{$coord_field}",
+  );
+  $solr_query = format_string("PID:\"!pid\" OR PID:\"info:fedora/!pid\"",
+    array(
+      '!pid' => $object->id,
+    )
+  );
+  try {
+    $solr_build->buildQuery($solr_query, $params);
+    _islandora_simple_map_remove_search_restrictions($solr_build->solrParams);
+    $solr_build->executeQuery(FALSE);
+    $results = $solr_build->islandoraSolrResult['response']['objects'];
+  }
+  catch (Exception $e) {
+    drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error');
+  }
+  $member = reset($results);
+  if (isset($member['solr_doc'][$coord_field])) {
+    if (is_array($member['solr_doc'][$coord_field])) {
+      $found_coords = $member['solr_doc'][$coord_field];
+    }
+    else {
+      $found_coords = array($member['solr_doc'][$coord_field]);
     }
   }
   return $found_coords;
@@ -230,7 +290,8 @@ function _islandora_simple_map_collection_map_enabled() {
  */
 function _islandora_simple_map_get_collection_points(AbstractObject $object) {
   $points = array();
-  if (module_exists('islandora_solr') && variable_get('islandora_simple_map_collection_coord_solr_field', '') !== '') {
+  if (module_exists('islandora_solr') &&
+    variable_get('islandora_simple_map_use_solr', FALSE)) {
     $points = _islandora_simple_map_get_collection_points_solr($object);
   }
   elseif (module_exists('islandora_basic_collection')) {
@@ -286,17 +347,12 @@ function _islandora_simple_map_get_collection_points_load(AbstractObject $object
 function _islandora_simple_map_get_collection_points_solr(AbstractObject $object) {
   $points = array();
   $member_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
-  $coord_field = variable_get('islandora_simple_map_collection_coord_solr_field', '');
+  $coord_field = variable_get('islandora_simple_map_coordinate_solr_field', '');
   $page_num = 0;
   $page_size = 20;
   $count = NULL;
   $members = array();
   $solr_build = new IslandoraSolrQueryProcessor();
-  $params = array(
-    'rows' => $page_size,
-    'start' => $page_num,
-    'fl' => "PID,{$coord_field}",
-  );
   $solr_query = format_string("!member:\"!pid\" OR !member:\"info:fedora/!pid\"",
     array(
       '!member' => $member_field,
@@ -304,8 +360,15 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
     )
   );
   while (is_null($count) || ($count > ($page_num * $page_size) + $page_size)) {
+    $params = array(
+      'rows' => $page_size,
+      'start' => $page_num,
+      'fl' => "PID,{$coord_field}",
+    );
     try {
-      $solr_build->buildAndExecuteQuery($solr_query, $params, FALSE);
+      $solr_build->buildQuery($solr_query, $params);
+      _islandora_simple_map_remove_search_restrictions($solr_build->solrParams);
+      $solr_build->executeQuery(FALSE);
       $results = $solr_build->islandoraSolrResult;
       $count = $results['response']['numFound'];
       $members = array_merge($members, $results['response']['objects']);
@@ -319,14 +382,24 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
   foreach ($members as $member) {
     if (isset($member['solr_doc'][$coord_field])) {
       if (is_array($member['solr_doc'][$coord_field])) {
-        $coords = $member['solr_doc'][$coord_field];
+        $coordinates = $member['solr_doc'][$coord_field];
       }
       else {
-        $coords = array($member['solr_doc'][$coord_field]);
+        $coordinates = array($member['solr_doc'][$coord_field]);
       }
+      $coordinates = islandora_simple_map_parse_coordinates($coordinates);
+      if (variable_get('islandora_simple_map_attempt_cleanup', TRUE)) {
+        array_walk($coordinates, 'islandora_simple_map_clean_coordinates');
+      }
+      if (variable_get('islandora_simple_map_use_gmaps_api', FALSE)) {
+        // Only filter and standardize coordinates if we are using Javascript API.
+        $coordinates = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
+        array_walk($coordinates, 'islandora_simple_map_standardize_format');
+      }
+
       $points[] = array(
         'pid' => $member['PID'],
-        'coordinates' => $coords,
+        'coordinates' => $coordinates,
       );
     }
   }
@@ -377,4 +450,18 @@ function _islandora_simple_map_generate_js_code(array $settings) {
       ),
     ),
   );
+}
+
+/**
+ * Remove the various search alters that stop us from getting any data from Solr.
+ *
+ * @param array $params
+ *   The islandoraSolrQueryProcessor params
+ */
+function _islandora_simple_map_remove_search_restrictions(array &$params) {
+  if (module_exists('islandora_compound_object') &&
+    variable_get('islandora_compound_object_hide_child_objects_solr', TRUE)) {
+    $fq = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
+    $params['fq'] = array_diff($params['fq'], array($fq));
+  }
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -230,29 +230,108 @@ function _islandora_simple_map_collection_map_enabled() {
  */
 function _islandora_simple_map_get_collection_points(AbstractObject $object) {
   $points = array();
-  if (module_exists('islandora_basic_collection')) {
-    $page_num = 0;
-    $page_size = 20;
-    $count = NULL;
-    $members = array();
-    while (is_null($count) || ($count > ($page_num * $page_size) + $page_size)) {
-      list($count, $new_members) = islandora_basic_collection_get_member_objects($object, $page_num, $page_size);
-      $members = array_merge($members, $new_members);
-      $page_num += 1;
-    }
-    if (count($members) > 0) {
-      foreach ($members as $member) {
-        $pid = $member['object']['value'];
-        $object = islandora_object_load($pid);
-        if ($object) {
-          $coords = islandora_simple_map_process_coordinates($object);
-          if (isset($coords['coordinates']) && count($coords['coordinates']) > 0) {
-            $points[] = $coords;
-          }
+  if (module_exists('islandora_solr') && variable_get('islandora_simple_map_collection_coord_solr_field', '') !== '') {
+    $points = _islandora_simple_map_get_collection_points_solr($object);
+  }
+  else if (module_exists('islandora_basic_collection')) {
+    $points = _islandora_simple_map_get_collection_points_load($object);
+  }
+  return $points;
+}
+
+/**
+ * Get all the collection points from a collection by parsing MODS records.
+ *
+ * @param \AbstractObject $object
+ *   The collection object.
+ *
+ * @return array
+ *   The collection points (un-parsed).
+ */
+function _islandora_simple_map_get_collection_points_load(AbstractObject $object) {
+  $points = array();
+  $page_num = 0;
+  $page_size = 20;
+  $count = NULL;
+  $members = array();
+  while (is_null($count) || ($count > ($page_num * $page_size) + $page_size)) {
+    list($count, $new_members) = islandora_basic_collection_get_member_objects($object, $page_num, $page_size);
+    $members = array_merge($members, $new_members);
+    $page_num += 1;
+  }
+  if (count($members) > 0) {
+    foreach ($members as $member) {
+      $pid = $member['object']['value'];
+      $object = islandora_object_load($pid);
+      if ($object) {
+        $coords = islandora_simple_map_process_coordinates($object);
+        if (isset($coords['coordinates']) && count($coords['coordinates']) > 0) {
+          $points[] = $coords;
         }
       }
     }
   }
+  return $points;
+}
+
+/**
+ * Get all the collection points from a collection by querying Solr.
+ *
+ * @param \AbstractObject $object
+ *   The collection object.
+ *
+ * @return array
+ *   The collection points (un-parsed).
+ */
+function _islandora_simple_map_get_collection_points_solr(AbstractObject $object) {
+  $points = array();
+  $member_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
+  $coord_field = variable_get('islandora_simple_map_collection_coord_solr_field', '');
+  $page_num = 0;
+  $page_size = 20;
+  $count = NULL;
+  $members = [];
+  $solr_build = new IslandoraSolrQueryProcessor();
+  $params = [
+    'rows' => $page_size,
+    'start' => $page_num,
+    'fl' => "PID,{$coord_field}",
+  ];
+  $solr_query = format_string("!member:\"!pid\" OR !member:\"info:fedora/!pid\"",
+    [
+      '!member' => $member_field,
+      '!pid' => $object->id,
+    ]
+  );
+  while (is_null($count) || ($count > ($page_num * $page_size) + $page_size)) {
+    try {
+      $solr_build->buildAndExecuteQuery($solr_query, $params, FALSE);
+      $results = $solr_build->islandoraSolrResult;
+      $count = $results['response']['numFound'];
+      $members = array_merge($members, $results['response']['objects']);
+      $page_num += 1;
+    } catch (Exception $e) {
+      drupal_set_message("Error querying Solr index: {$e->getMessage}", "error");
+      break;
+    }
+  }
+  foreach ($members as $member) {
+    if (isset($member['solr_doc'][$coord_field])) {
+      if (is_array($member['solr_doc'][$coord_field])) {
+        $coords = $member['solr_doc'][$coord_field];
+      }
+      else {
+        $coords = [$member['solr_doc'][$coord_field]];
+      }
+      $points[] = [
+        'pid' => $member['PID'],
+        'coordinates' => $coords,
+      ];
+    }
+  }
+  $points = array_filter($points, function($o) {
+    return count($o['coordinates'] > 0);
+  });
   return $points;
 }
 

--- a/islandora_simple_map.install
+++ b/islandora_simple_map.install
@@ -20,6 +20,8 @@ function islandora_simple_map_uninstall() {
     'islandora_simple_map_disable_scroll',
     'islandora_simple_map_disable_page_display',
     'islandora_simple_map_coordinate_delimiter',
+    'islandora_simple_map_coordinate_solr_field',
+    'islandora_simple_map_use_solr',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -307,6 +307,7 @@ function islandora_simple_map_collection_map_view(AbstractObject $object) {
         ),
       ),
     );
+    dsm($content);
   }
   else {
     $content = array(

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -307,7 +307,6 @@ function islandora_simple_map_collection_map_view(AbstractObject $object) {
         ),
       ),
     );
-    dsm($content);
   }
   else {
     $content = array(


### PR DESCRIPTION
Partially resolves #26 

This covers the collection map display part of that issue. It allows you to select a Solr field that contains coordinates. If that field is populated then when generating a collection map it will perform a Solr query for the provided coordinates field.

Otherwise it goes back to parse each objects MODS record to retrieve the coordinates. 

Ideally using Solr or not should only impact speed and not have an impact on the end result.

Currently my dev site is using this setup here - > http://niobe.lib.umanitoba.ca/islandora/object/uofm%3Apaum/maps