### PR TITLE
Coordinates not parsed are still returned.

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -90,6 +90,10 @@ function islandora_simple_map_parse_coordinates(array $coordinates) {
       break;
     }
   }
+  if (count($to_process) > 0) {
+    // Stick un-parsed coordinates back in the mix.
+    $processed = array_merge($processed, array_values($to_process));
+  }
   return $processed;
 }
 

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -75,7 +75,13 @@ function islandora_simple_map_parse_coordinates(array $coordinates) {
   // Don't need to parse coordinates already in decimal notation.
   $processed = array_filter($coordinates, 'islandora_simple_map_is_valid_coordinates');
   $coordinates = array_diff($coordinates, $processed);
-  $to_process = array_combine($coordinates, $coordinates);
+  // TODO: PHP 5.3.3 needs this check or it throws a fit. Dump it when we can.
+  if (count($coordinates) > 0) {
+    $to_process = array_combine($coordinates, $coordinates);
+  }
+  else {
+    $to_process = array();
+  }
   foreach ($hooks as $hook) {
     if (isset($hook['file'])) {
       require_once $hook['file'];

--- a/tests/hooks.test
+++ b/tests/hooks.test
@@ -73,7 +73,77 @@ class IslandoraSimpleMapHookTestCase extends IslandoraSimpleMapTestCase {
    * Test hook_islandora_simple_map_parse_coordinates().
    */
   public function testParseCoordinates() {
+    $coordinates = array(
+      '45.4215, -75.6972',
+    );
+
+    $expected = array(
+      '45.4215, -75.6972',
+    );
+
+    $new_coords = islandora_simple_map_parse_coordinates($coordinates);
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parse coordinates returned expected decimal result.');
+
+    $coordinates = array(
+      '32° 42\' 56.6496" N, 117° 9\' 39.9132" W',
+    );
+
+    $expected = array(
+      '32° 42\' 56.6496" N, 117° 9\' 39.9132" W',
+    );
+
+    $new_coords = islandora_simple_map_parse_coordinates($coordinates);
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parsed coordinates returned expected DMS result.');
+
+    $coordinates = array(
+      'Kanaka Creek, BC',
+    );
+
+    $expected = array(
+      'Kanaka Creek, BC',
+    );
+
+    $new_coords = islandora_simple_map_parse_coordinates($coordinates);
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parsed coordinates returned expected text result.');
+
+    $coordinates = array(
+      '45.4215, -75.6972',
+      '32° 42\' 56.6496" N, 117° 9\' 39.9132" W',
+    );
+
+    $expected = array(
+      '45.4215, -75.6972',
+      '32° 42\' 56.6496" N, 117° 9\' 39.9132" W',
+    );
+
+    $new_coords = islandora_simple_map_parse_coordinates($coordinates);
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parsed coordinates returned expected decimal and DMS results.');
+
+    $coordinates = array(
+      '45.4215, -75.6972',
+      'Kanaka Creek, BC',
+    );
+
+    $expected = array(
+      '45.4215, -75.6972',
+      'Kanaka Creek, BC',
+    );
+
+    $new_coords = islandora_simple_map_parse_coordinates($coordinates);
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parsed coordinates returned expected decimal and text results.');
+
     module_enable(array('islandora_simple_map_hooks_test'));
+    $coordinates = array(
+      '45.4215, -75.6972',
+    );
+
+    $expected = array(
+      '45.4215, -75.6972',
+    );
+
+    $new_coords = islandora_simple_map_parse_coordinates($coordinates);
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parse coordinates returned expected results.');
+
     $coordinates = array(
       '45.4215, -75.6972',
       '43.6532, -79.3832',
@@ -89,7 +159,24 @@ class IslandoraSimpleMapHookTestCase extends IslandoraSimpleMapTestCase {
     );
 
     $new_coords = islandora_simple_map_parse_coordinates($coordinates);
-    $this->assertEqual($expected, $new_coords, 'Hook parse coordinates did not return expected results.');
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parse coordinates returned expected results.');
+
+    $coordinates = array(
+      '45.4215, -75.6972',
+      '43.6532, -79.3832',
+      'Kanaka Creek, BC',
+      '32° 42\' 56.6496" N, 117° 9\' 39.9132" W',
+    );
+
+    $expected = array(
+      '45.4215, -75.6972',
+      '43.6532, -79.3832',
+      'Kanaka Creek, BC',
+      '32.715736, -117.161087',
+    );
+
+    $new_coords = islandora_simple_map_parse_coordinates($coordinates);
+    $this->assertArrayEquals($expected, $new_coords, 'Hook parse coordinates returned expected results.');
   }
 
   /**

--- a/tests/includes/simple_map_test_case.inc
+++ b/tests/includes/simple_map_test_case.inc
@@ -82,4 +82,66 @@ class IslandoraSimpleMapTestCase extends IslandoraWebTestCase {
     variable_set('islandora_simple_map_use_gmaps_api', $val);
   }
 
+  /**
+   * Compare arrays regardless of order.
+   *
+   * @param array $expected
+   *   The expected array.
+   * @param array $actual
+   *   The actual result array.
+   * @param $message
+   *   The test message.
+   *
+   * @return bool
+   *   The test result.
+   */
+  protected function assertArrayEquals(array $expected, array $actual, $message) {
+    if (count($expected) !== count($actual)) {
+      return $this->fail($message);
+    }
+    $expect_assoc = (count(array_filter(array_keys($expected), 'is_string')) > 0);
+    if ($expect_assoc) {
+      if (count(array_filter(array_keys($actual), 'is_string')) > 0) {
+        return $this->fail($message);
+      }
+      else {
+        // Associative
+        foreach ($expected as $k => $v) {
+          if (!array_key_exists($k, $actual) || $v !== $actual[$k]) {
+            // Key or value does not match.
+            return $this->fail($message);
+          }
+          else {
+            // Remove matched entry from $actual.
+            unset($actual[$k]);
+          }
+        }
+      }
+    }
+    else {
+      foreach ($expected as $v) {
+        if (!in_array($v, $actual)) {
+          // Value not in $actual.
+          return $this->fail($message);
+        }
+        else {
+          $tempKey = $index = array_search($v, $actual);
+          if ($tempKey !== FALSE) {
+            unset($actual[$tempKey]);
+          }
+          else {
+            return $this->fail($message . " -- Error removing key value");
+          }
+        }
+      }
+    }
+    if (count($actual) == 0) {
+      // No excess values left.
+      return $this->pass($message);
+    }
+    else {
+      // Still items in $actual.
+      return $this->fail($message);
+    }
+  }
 }

--- a/tests/includes/simple_map_test_case.inc
+++ b/tests/includes/simple_map_test_case.inc
@@ -89,7 +89,7 @@ class IslandoraSimpleMapTestCase extends IslandoraWebTestCase {
    *   The expected array.
    * @param array $actual
    *   The actual result array.
-   * @param $message
+   * @param string $message
    *   The test message.
    *
    * @return bool
@@ -105,7 +105,7 @@ class IslandoraSimpleMapTestCase extends IslandoraWebTestCase {
         return $this->fail($message);
       }
       else {
-        // Associative
+        // Associative arrays.
         foreach ($expected as $k => $v) {
           if (!array_key_exists($k, $actual) || $v !== $actual[$k]) {
             // Key or value does not match.
@@ -125,9 +125,9 @@ class IslandoraSimpleMapTestCase extends IslandoraWebTestCase {
           return $this->fail($message);
         }
         else {
-          $tempKey = $index = array_search($v, $actual);
-          if ($tempKey !== FALSE) {
-            unset($actual[$tempKey]);
+          $temp_key = $index = array_search($v, $actual);
+          if ($temp_key !== FALSE) {
+            unset($actual[$temp_key]);
           }
           else {
             return $this->fail($message . " -- Error removing key value");


### PR DESCRIPTION
Resolves #44 

The previous logic filtered decimal coordinates directly through and then passed any parsed coordinates through to. 

But if a non-decimal coordinate was found but **not** parsed it was tossed.

This makes sure that if any coordinates are not parsed after all the hooks are called they are passed back in the returned values.

If you are using the Javascript API this list is then filtered to return only decimal coordinates, but for the Embed API this might be an issue.

Tests are included to cover a bunch more interactions.