### PR TITLE
Correct paging of Solr and triplestore for collection maps

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -358,7 +358,7 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
   $points = array();
   $member_field = variable_get('islandora_solr_member_of_collection_field', 'RELS_EXT_isMemberOfCollection_uri_ms');
   $coord_field = variable_get('islandora_simple_map_coordinate_solr_field', '');
-  $page_num = 0;
+  $page_num = -1;
   $page_size = 20;
   $count = NULL;
   $members = array();
@@ -369,26 +369,29 @@ function _islandora_simple_map_get_collection_points_solr(AbstractObject $object
       '!pid' => $object->id,
     )
   );
-  while (is_null($count) || ($count > ($page_num * $page_size) + $page_size)) {
-    $params = array(
-      'rows' => $page_size,
-      'start' => $page_num,
-      'fl' => "PID,{$coord_field}",
-    );
+  $params = array(
+    'fl' => "PID,{$coord_field}",
+  );
+
+  $solr_build->buildQuery($solr_query, $params);
+  _islandora_simple_map_remove_search_restrictions($solr_build->solrParams);
+
+  do {
+    $page_num += 1;
     try {
-      $solr_build->buildQuery($solr_query, $params);
-      _islandora_simple_map_remove_search_restrictions($solr_build->solrParams);
+      $solr_build->solrStart = $page_num * $page_size;
+      $solr_build->solrLimit = $page_size;
       $solr_build->executeQuery(FALSE);
       $results = $solr_build->islandoraSolrResult;
       $count = $results['response']['numFound'];
       $members = array_merge($members, $results['response']['objects']);
-      $page_num += 1;
     }
     catch (Exception $e) {
       drupal_set_message(check_plain(t('Error searching Solr index')) . ' ' . $e->getMessage(), 'error');
       break;
     }
-  }
+  } while (is_null($count) || ($count > ($page_num * $page_size) + $page_size));
+
   foreach ($members as $member) {
     if (isset($member['solr_doc'][$coord_field])) {
       if (is_array($member['solr_doc'][$coord_field])) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -321,15 +321,16 @@ function _islandora_simple_map_get_collection_points(AbstractObject $object) {
  */
 function _islandora_simple_map_get_collection_points_load(AbstractObject $object) {
   $points = array();
-  $page_num = 0;
+  $page_num = -1;
   $page_size = 20;
   $count = NULL;
   $members = array();
-  while (is_null($count) || ($count > ($page_num * $page_size) + $page_size)) {
+  do {
+    $page_num += 1;
     list($count, $new_members) = islandora_basic_collection_get_member_objects($object, $page_num, $page_size);
     $members = array_merge($members, $new_members);
-    $page_num += 1;
-  }
+  } while (is_null($count) || ($count > ($page_num * $page_size) + $page_size));
+
   if (count($members) > 0) {
     foreach ($members as $member) {
       $pid = $member['object']['value'];


### PR DESCRIPTION
Resolves #46 

There were various problems with my previous logic, I'd love to mock a solr object to have some tests of this but we can leave that for now.

What went wrong.
1. `'start' => $page_num,`  which meant that I was setting `$start` to 0, 1, 2 instead of 0, 20, 40
1. `$solr_build->solrStart = $page_num * $page_size;` the above didn't seem to matter as internal to the `IslandoraSolrQueryProcessor` it appeared that the `solrStart` was not changing based on the passed parameter.
1. Moved `while {}` to `do {} while` because the loop exited one iteration too early and missed the last objects.

Hopefully this should resolve the issues, but if @mjordan can check with his massive collection of objects that would be great.