### PR TITLE
Add anonymous caching of collection map points

### DIFF
--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -67,6 +67,18 @@ function islandora_simple_map_admin_settings() {
       '#default_value' => variable_get('islandora_simple_map_collection_maps', FALSE),
       '#return_value' => TRUE,
     ),
+    'islandora_simple_map_collection_maps_cache' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Enable collection map cache for anonymous users.'),
+      '#description' => t('This will cache the marker points for a collection map to speed up the map loading. This is only enabled for anonymous users to avoid issues in caching privileged objects.'),
+      '#default_value' => variable_get('islandora_simple_map_collection_maps_cache', FALSE),
+      '#return_value' => TRUE,
+      '#states' => array(
+        'visible' => array(
+          ':input[name="islandora_simple_map_collection_maps"]' => array('checked' => TRUE),
+        ),
+      ),
+    ),
   );
   $form['islandora_simple_map_solr_fieldset'] = array(
     '#type' => 'fieldset',
@@ -151,6 +163,7 @@ function islandora_simple_map_admin_settings() {
     '#default_value' => variable_get('islandora_simple_map_omit_compound_display', TRUE),
   );
   $form['#validate'][] = 'islandora_simple_map_admin_settings_form_validate';
+  $form['#submit'][] = 'islandora_simple_map_admin_settings_cache_check';
   return system_settings_form($form);
 }
 
@@ -172,6 +185,21 @@ function islandora_simple_map_admin_settings_form_validate(array $form, array &$
     && $form_state['values']['islandora_simple_map_use_solr'] == TRUE) {
     form_set_error('islandora_simple_map_coordinate_solr_field',
       'You must specify a field for coordinates to use Solr.');
+  }
+}
+
+/**
+ * Clear all caches if caching or collection maps are disabled.
+ *
+ * @param $form
+ *   The Drupal form.
+ * @param $form_state
+ *   The Drupal form state.
+ */
+function islandora_simple_map_admin_settings_cache_check($form, $form_state) {
+  if ($form_state['values']['islandora_simple_map_collection_maps_cache'] != TRUE ||
+    $form_state['values']['islandora_simple_map_collection_maps'] != TRUE) {
+    cache_clear_all(ISLANDORA_SIMPLE_MAP_CACHE_PREFIX, ISLANDORA_SIMPLE_MAP_CACHE_BIN, TRUE);
   }
 }
 

--- a/includes/admin_form.inc
+++ b/includes/admin_form.inc
@@ -191,12 +191,12 @@ function islandora_simple_map_admin_settings_form_validate(array $form, array &$
 /**
  * Clear all caches if caching or collection maps are disabled.
  *
- * @param $form
+ * @param array $form
  *   The Drupal form.
- * @param $form_state
+ * @param array $form_state
  *   The Drupal form state.
  */
-function islandora_simple_map_admin_settings_cache_check($form, $form_state) {
+function islandora_simple_map_admin_settings_cache_check(array $form, array $form_state) {
   if ($form_state['values']['islandora_simple_map_collection_maps_cache'] != TRUE ||
     $form_state['values']['islandora_simple_map_collection_maps'] != TRUE) {
     cache_clear_all(ISLANDORA_SIMPLE_MAP_CACHE_PREFIX, ISLANDORA_SIMPLE_MAP_CACHE_BIN, TRUE);

--- a/includes/manage_collection_form.inc
+++ b/includes/manage_collection_form.inc
@@ -89,7 +89,7 @@ function islandora_simple_map_collection_manage_form_submit($form, &$form_state)
     }
     if ($clear_cache) {
       _islandora_simple_map_clear_cache($pid);
-      drupal_set_message('Cache cleared.');
+      drupal_set_message(t('Cache cleared.'));
     }
   }
 }

--- a/includes/manage_collection_form.inc
+++ b/includes/manage_collection_form.inc
@@ -56,7 +56,7 @@ function islandora_simple_map_collection_manage_form_submit($form, &$form_state)
     $pid = $form_state['values']['islandora_simple_map_collection_pid'];
     $clear_cache = FALSE;
     if (isset($form_state['triggering_element']['#value']) &&
-      $form_state['triggering_element']['#value'] == 'Clear cache') {
+      $form_state['triggering_element']['#value'] == t('Clear cache')) {
       $clear_cache = TRUE;
     }
     else {

--- a/includes/manage_collection_form.inc
+++ b/includes/manage_collection_form.inc
@@ -30,6 +30,18 @@ function islandora_simple_map_collection_manage_form($form, &$form_state, $objec
       '#value' => t('Save'),
     ),
   );
+  $cache = _islandora_simple_map_get_cache($object->id);
+  if ($cache !== FALSE) {
+    $form['islandora_simple_map_cache_created'] = array(
+      '#type' => 'item',
+      '#title' => t('Cache created'),
+      '#markup' => date('c', $cache->created),
+    );
+    $form['islandora_simple_map_cache_clear'] = array(
+      '#type' => 'submit',
+      '#value' => t('Clear cache'),
+    );
+  }
   return $form;
 }
 
@@ -42,27 +54,42 @@ function islandora_simple_map_collection_manage_form_submit($form, &$form_state)
   if (isset($form_state['values']['islandora_simple_map_collection_pid']) &&
     !empty($form_state['values']['islandora_simple_map_collection_pid'])) {
     $pid = $form_state['values']['islandora_simple_map_collection_pid'];
-    $has_collection_map = _islandora_simple_map_display_collection_map($pid);
-    if ((bool) $form_state['values']['islandora_simple_map_display'] == FALSE &&
-      $has_collection_map) {
-      $num_deleted = db_delete('islandora_simple_map_collections_map')->condition('pid', $pid)->execute();
-      if ($num_deleted !== 1) {
-        form_set_error('islandora_simple_map_display', 'Problem unsetting collection map.');
+    $clear_cache = FALSE;
+    if (isset($form_state['triggering_element']['#value']) &&
+      $form_state['triggering_element']['#value'] == 'Clear cache') {
+      $clear_cache = TRUE;
+    }
+    else {
+      $has_collection_map = _islandora_simple_map_display_collection_map($pid);
+      if ((bool) $form_state['values']['islandora_simple_map_display'] == FALSE &&
+        $has_collection_map) {
+        $num_deleted = db_delete('islandora_simple_map_collections_map')
+          ->condition('pid', $pid)
+          ->execute();
+        if ($num_deleted !== 1) {
+          form_set_error('islandora_simple_map_display', 'Problem unsetting collection map.');
+        }
+        else {
+          drupal_set_message(t("Collection map display disabled."));
+          // Also clear cache when we disable a collection map.
+          $clear_cache = TRUE;
+        }
       }
-      else {
-        drupal_set_message(t("Collection map display disabled."));
+      elseif ((bool) $form_state['values']['islandora_simple_map_display'] == TRUE &&
+        !$has_collection_map) {
+        $object = islandora_object_load($pid);
+        if ($object) {
+          db_insert('islandora_simple_map_collections_map')->fields([
+            'pid' => $pid,
+            'title' => check_plain($object->label),
+          ])->execute();
+          drupal_set_message(t("Collection map display enabled."));
+        }
       }
     }
-    elseif ((bool) $form_state['values']['islandora_simple_map_display'] == TRUE &&
-      !$has_collection_map) {
-      $object = islandora_object_load($pid);
-      if ($object) {
-        db_insert('islandora_simple_map_collections_map')->fields(array(
-          'pid' => $pid,
-          'title' => check_plain($object->label),
-        ))->execute();
-        drupal_set_message(t("Collection map display enabled."));
-      }
+    if ($clear_cache) {
+      _islandora_simple_map_clear_cache($pid);
+      drupal_set_message('Cache cleared.');
     }
   }
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -305,11 +305,9 @@ function _islandora_simple_map_get_collection_points(AbstractObject $object) {
     // Caching for anonymous users.
     $cache_roles = 'anonymous';
     $coordinate_cache = &drupal_static(__FUNCTION__);
-    // Separate cache object for each collection.
-    $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $object->id);
     $from_cache = FALSE;
     if (!isset($coordinate_cache)) {
-      $cache = cache_get($cache_name);
+      $cache = _islandora_simple_map_get_cache($object->id);
       if ($cache !== FALSE) {
         $coordinate_cache = $cache->data;
       }
@@ -330,7 +328,7 @@ function _islandora_simple_map_get_collection_points(AbstractObject $object) {
     }
     if (isset($from_cache)) {
       $coordinate_cache[$cache_roles] = $points;
-      cache_set($cache_name, $coordinate_cache);
+      _islandora_simple_map_set_cache($object->id, $coordinate_cache);
     }
   }
   return $points;
@@ -504,4 +502,42 @@ function _islandora_simple_map_remove_search_restrictions(array &$params) {
     $fq = variable_get('islandora_compound_object_solr_fq', '-RELS_EXT_isConstituentOf_uri_mt:[* TO *]');
     $params['fq'] = array_diff($params['fq'], array($fq));
   }
+}
+
+/**
+ * Utility function to get the collection cache.
+ *
+ * @param $pid
+ *   The collection PID.
+ *
+ * @return mixed
+ *   The cache or FALSE.
+ */
+function _islandora_simple_map_get_cache($pid) {
+  $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $pid);
+  return cache_get($cache_name, ISLANDORA_SIMPLE_MAP_CACHE_BIN);
+}
+
+/**
+ * Utility function to set the collection map cache.
+ *
+ * @param $pid
+ *   The collection PID.
+ * @param $data
+ *   The cached data.
+ */
+function _islandora_simple_map_set_cache($pid, $data) {
+  $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $pid);
+  cache_set($cache_name, $data, ISLANDORA_SIMPLE_MAP_CACHE_BIN);
+}
+
+/**
+ * Utility function to clear collection map cache.
+ *
+ * @param $pid
+ *   The collection PID.
+ */
+function _islandora_simple_map_clear_cache($pid) {
+  $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $pid);
+  cache_clear_all($cache_name, ISLANDORA_SIMPLE_MAP_CACHE_BIN, TRUE);
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -507,7 +507,7 @@ function _islandora_simple_map_remove_search_restrictions(array &$params) {
 /**
  * Utility function to get the collection cache.
  *
- * @param $pid
+ * @param string $pid
  *   The collection PID.
  *
  * @return mixed
@@ -526,9 +526,9 @@ function _islandora_simple_map_get_cache($pid) {
 /**
  * Utility function to set the collection map cache.
  *
- * @param $pid
+ * @param string $pid
  *   The collection PID.
- * @param $data
+ * @param mixed $data
  *   The cached data.
  */
 function _islandora_simple_map_set_cache($pid, $data) {
@@ -541,7 +541,7 @@ function _islandora_simple_map_set_cache($pid, $data) {
 /**
  * Utility function to clear collection map cache.
  *
- * @param $pid
+ * @param string $pid
  *   The collection PID.
  */
 function _islandora_simple_map_clear_cache($pid) {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -514,8 +514,13 @@ function _islandora_simple_map_remove_search_restrictions(array &$params) {
  *   The cache or FALSE.
  */
 function _islandora_simple_map_get_cache($pid) {
-  $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $pid);
-  return cache_get($cache_name, ISLANDORA_SIMPLE_MAP_CACHE_BIN);
+  if (variable_get('islandora_simple_map_collection_maps_cache', FALSE)) {
+    $cache_name = ISLANDORA_SIMPLE_MAP_CACHE_PREFIX . str_replace(':', '_', $pid);
+    return cache_get($cache_name, ISLANDORA_SIMPLE_MAP_CACHE_BIN);
+  }
+  else {
+    return FALSE;
+  }
 }
 
 /**
@@ -527,8 +532,10 @@ function _islandora_simple_map_get_cache($pid) {
  *   The cached data.
  */
 function _islandora_simple_map_set_cache($pid, $data) {
-  $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $pid);
-  cache_set($cache_name, $data, ISLANDORA_SIMPLE_MAP_CACHE_BIN);
+  if (variable_get('islandora_simple_map_collection_maps_cache', FALSE)) {
+    $cache_name = ISLANDORA_SIMPLE_MAP_CACHE_PREFIX . str_replace(':', '_', $pid);
+    cache_set($cache_name, $data, ISLANDORA_SIMPLE_MAP_CACHE_BIN);
+  }
 }
 
 /**
@@ -538,6 +545,6 @@ function _islandora_simple_map_set_cache($pid, $data) {
  *   The collection PID.
  */
 function _islandora_simple_map_clear_cache($pid) {
-  $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $pid);
-  cache_clear_all($cache_name, ISLANDORA_SIMPLE_MAP_CACHE_BIN, TRUE);
+  $cache_name = ISLANDORA_SIMPLE_MAP_CACHE_PREFIX . str_replace(':', '_', $pid);
+  cache_clear_all($cache_name, ISLANDORA_SIMPLE_MAP_CACHE_BIN, FALSE);
 }

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -300,12 +300,38 @@ function _islandora_simple_map_collection_map_enabled() {
  */
 function _islandora_simple_map_get_collection_points(AbstractObject $object) {
   $points = array();
-  if (module_exists('islandora_solr') &&
-    variable_get('islandora_simple_map_use_solr', FALSE)) {
-    $points = _islandora_simple_map_get_collection_points_solr($object);
+
+  if (user_is_anonymous()) {
+    // Caching for anonymous users.
+    $cache_roles = 'anonymous';
+    $coordinate_cache = &drupal_static(__FUNCTION__);
+    // Separate cache object for each collection.
+    $cache_name = 'islandora_simple_map_collection_map_' . str_replace(':', '_', $object->id);
+    $from_cache = FALSE;
+    if (!isset($coordinate_cache)) {
+      $cache = cache_get($cache_name);
+      if ($cache !== FALSE) {
+        $coordinate_cache = $cache->data;
+      }
+    }
+    if (isset($coordinate_cache[$cache_roles])) {
+      $points = $coordinate_cache[$cache_roles];
+      // Retrieved from cache.
+      $from_cache = TRUE;
+    }
   }
-  elseif (module_exists('islandora_basic_collection')) {
-    $points = _islandora_simple_map_get_collection_points_load($object);
+  if (!isset($from_cache) || $from_cache === FALSE) {
+    if (module_exists('islandora_solr') &&
+      variable_get('islandora_simple_map_use_solr', FALSE)) {
+      $points = _islandora_simple_map_get_collection_points_solr($object);
+    }
+    elseif (module_exists('islandora_basic_collection')) {
+      $points = _islandora_simple_map_get_collection_points_load($object);
+    }
+    if (isset($from_cache)) {
+      $coordinate_cache[$cache_roles] = $points;
+      cache_set($cache_name, $coordinate_cache);
+    }
   }
   return $points;
 }

--- a/islandora_simple_map.install
+++ b/islandora_simple_map.install
@@ -23,6 +23,7 @@ function islandora_simple_map_uninstall() {
     'islandora_simple_map_coordinate_solr_field',
     'islandora_simple_map_use_solr',
     'islandora_simple_map_collection_maps',
+    'islandora_simple_map_collection_maps_cache',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -8,6 +8,7 @@
 define('ISLANDORA_SIMPLE_MAP_XPATHS', "//mods:subject/mods:cartographics/mods:coordinates\n//mods:subject/mods:geographic");
 define('ISLANDORA_SIMPLE_MAP_COORDINATE_HOOK', 'islandora_simple_map_get_coordinates');
 define('ISLANDORA_SIMPLE_MAP_PARSE_HOOK', 'islandora_simple_map_parse_coordinates_callback');
+define('ISLANDORA_SIMPLE_MAP_CACHE_PREFIX', 'islandora_simple_map_collection_map_');
 define('ISLANDORA_SIMPLE_MAP_CACHE_BIN', 'cache');
 
 // Includes blocks.

--- a/islandora_simple_map.module
+++ b/islandora_simple_map.module
@@ -8,6 +8,7 @@
 define('ISLANDORA_SIMPLE_MAP_XPATHS', "//mods:subject/mods:cartographics/mods:coordinates\n//mods:subject/mods:geographic");
 define('ISLANDORA_SIMPLE_MAP_COORDINATE_HOOK', 'islandora_simple_map_get_coordinates');
 define('ISLANDORA_SIMPLE_MAP_PARSE_HOOK', 'islandora_simple_map_parse_coordinates_callback');
+define('ISLANDORA_SIMPLE_MAP_CACHE_BIN', 'cache');
 
 // Includes blocks.
 require_once dirname(__FILE__) . '/includes/blocks.inc';


### PR DESCRIPTION
Resolved #53 

This adds a new admin checkbox to enable caching on collection maps. Currently this only caches data for anonymous users, but I left some space if we decide to try and expand it.

I also added a place to clear the cache for a single collection on its Manage -> Collection -> Manage Islandora Simple Maps page.

If you disable caching or collection maps globally, then all caches are cleared.